### PR TITLE
falcon_cid syntax error

### DIFF
--- a/roles/falcon_installation/tasks/install.yml
+++ b/roles/falcon_installation/tasks/install.yml
@@ -76,7 +76,7 @@
     command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_cid }}"
     when:
       - not falcon_provisioning_token
-      - falcon_cid
+      - falcon_cid is defined
       - ansible_facts.packages is defined
       - installed_sensor in ansible_facts.packages
       - ansible_distribution != "MacOSX"
@@ -85,7 +85,7 @@
     command: "/Applications/Falcon.app/Contents/Resources/falconctl license {{ falcon_cid }}"
     when:
       - not falcon_provisioning_token
-      - falcon_cid
+      - falcon_cid is defined
       - ansible_distribution == "MacOSX"
       - falcon_already_installed is defined
       - not falcon_already_installed.stat.exists
@@ -103,7 +103,7 @@
     command: "/opt/CrowdStrike/falconctl -d -f --aid"
     when:
       - falcon_remove_agent_id
-      - falcon_cid
+      - falcon_cid is defined
       - ansible_facts.packages is defined
       - ansible_distribution != "MacOSX"
 


### PR DESCRIPTION
After making the changes, the playbook appears to work. Here is the error I was receiving:

```
TASK [falcon_installation : CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (Linux)] *******************************************************************************************************************************
[DEPRECATION WARNING]: evaluating u'falcon_cid' as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle. This feature will be
removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [<host here>]: FAILED! => {"msg": "The conditional check 'falcon_cid' failed. The error was: Invalid conditional detected: invalid syntax (<unknown>, line 1)\n\nThe error appears to be in '/home/thecasual/ansible/ansible_collection_falcon/roles/falcon_installation/tasks/install.yml': line 75, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (Linux)\n    ^ here\n"}
```