### PR TITLE
changed to `contains` to address #56

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.3.0
+version: 2.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_installation/tasks/api.yml
+++ b/roles/falcon_installation/tasks/api.yml
@@ -33,7 +33,7 @@
 
 - name: CrowdStrike Falcon | Get SHA256 hash of Falcon installer for the required OS Version
   set_fact:
-    falcon_api_sha_hash: "{{ falcon_api_installer_list.json.resources | selectattr('os_version', 'equalto', ansible_distribution_major_version ) }}"
+    falcon_api_sha_hash: "{{ falcon_api_installer_list.json.resources | selectattr('os_version', 'contains', ansible_distribution_major_version ) }}"
 
 - name: CrowdStrike Falcon | Detect Name of Latest Falcon Sensor
   uri:


### PR DESCRIPTION
This PR addresses issue #56 

the `os_version`  comes back as a string
it sometimes contains 1 version ie `8 `for RHEL/CENTOS
sometimes it comes base as multiple versions ie `16/18/20` for ubuntu

to handle this properly have made the change to `contains` from `equalto` in api.yml