### PR TITLE
Use FQCN instead of short names for modules

### DIFF
--- a/roles/falcon_installation/tasks/api.yml
+++ b/roles/falcon_installation/tasks/api.yml
@@ -1,6 +1,6 @@
 ---
 - name: CrowdStrike Falcon | Authenticate to CrowdStrike API
-  uri:
+  ansible.builtin.uri:
     url: "https://{{ falcon_cloud }}/oauth2/token"
     method: POST
     body_format: json
@@ -13,7 +13,7 @@
   register: falcon_api_oauth2_token
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
-  uri:
+  ansible.builtin.uri:
     url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
     method: GET
     return_content: true
@@ -27,7 +27,7 @@
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
-  uri:
+  ansible.builtin.uri:
     url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"
     method: GET
     return_content: true
@@ -37,7 +37,7 @@
   register: falcon_api_installer_list
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
-  get_url:
+  ansible.builtin.get_url:
     url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_api_installer_list.json.resources[falcon_sensor_version | int].sha256 }}"
     dest: "{{ falcon_install_tmp_dir }}"
     checksum: "sha256:{{ falcon_api_installer_list.json.resources[falcon_sensor_version | int].sha256 }}"
@@ -46,10 +46,10 @@
   register: falcon_sensor_download
 
 - name: CrowdStrike Falcon | Set CID received from API
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"
   when: not falcon_cid
 
 - name: CrowdStrike Falcon | Set full file download path
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ falcon_sensor_download.dest }}"

--- a/roles/falcon_installation/tasks/install.yml
+++ b/roles/falcon_installation/tasks/install.yml
@@ -1,32 +1,27 @@
 ---
-#- name: CrowdStrike Falcon | Verify Customer CID Is Configured
-#  fail:
-#    msg: "falcon_cid has not been configured! This is needed to register the Falcon Sensor. Please re-run the install with your Customer CID."
-#  when: not falcon_cid
-
 - block:
   - name: CrowdStrike Falcon | Set default sensor name
-    set_fact:
+    ansible.builtin.set_fact:
       installed_sensor: falcon-sensor
     when:
       - ansible_pkg_mgr in linux_packagers
 
   - name: CrowdStrike Falcon | Set default sensor name for non-Windows installations
-    set_fact:
+    ansible.builtin.set_fact:
       falcon_sensor_pkg: "{{ installed_sensor }}"
     when:
       - ansible_pkg_mgr in linux_packagers
       - falcon_sensor_download is not defined
 
   - name: CrowdStrike Falcon | Transfer CrowdStrike Falcon RPM GPG key file
-    copy:
+    ansible.builtin.copy:
       src: "{{ falcon_gpg_key }}"
       dest: "{{ falcon_install_tmp_dir }}{{ falcon_gpg_key }}"
     when:
       - falcon_gpg_key_check
 
   - name: CrowdStrike Falcon | Import CrowdStrike Falcon RPM GPG key from file
-    rpm_key:
+    ansible.builtin.rpm_key:
       state: present
       key: '{{ falcon_install_tmp_dir }}{{ falcon_gpg_key }}'
     when:
@@ -34,7 +29,7 @@
       - ansible_pkg_mgr in rpm_packagers
 
   - name: CrowdStrike Falcon | Import CrowdStrike Falcon APT GPG key from file
-    apt_key:
+    ansible.builtin.apt_key:
       file: '{{ falcon_install_tmp_dir }}{{ falcon_gpg_key }}'
       state: present
     when:
@@ -42,7 +37,7 @@
       - ansible_pkg_mgr in dpkg_packagers
 
   - name: CrowdStrike Falcon | Install Falcon Sensor .deb Package (Linux)
-    apt:
+    ansible.builtin.apt:
       deb: "{{ falcon_sensor_pkg }}"
       state: present
       force: yes # deb's way to downgrade
@@ -50,7 +45,7 @@
       - ansible_pkg_mgr in dpkg_packagers
 
   - name: CrowdStrike Falcon | Install Falcon Sensor .rpm Package (Linux)
-    yum:
+    ansible.builtin.yum:
       name: "{{ falcon_sensor_pkg }}"
       state: present
       allow_downgrade: yes
@@ -58,19 +53,19 @@
       - ansible_pkg_mgr in rpm_packagers
 
   - name: CrowdStrike Falcon | Install Falcon Sensor .pkg Package (macOS)
-    command: "/usr/sbin/installer -pkg {{ falcon_sensor_pkg }} -target /"
+    ansible.builtin.command: "/usr/sbin/installer -pkg {{ falcon_sensor_pkg }} -target /"
     args:
       creates: "/Applications/Falcon.app/Contents/Resources/falconctl"
     when:
       - ansible_distribution == "MacOSX"
 
   - name: CrowdStrike Falcon | Verify Falcon Package Is Installed
-    package_facts:
+    ansible.builtin.package_facts:
       manager: auto
     when: ansible_distribution != "MacOSX"
 
   - name: CrowdStrike Falcon | Check if Customer ID (CID) is associated with Falcon Sensor (Linux)
-    command: "/opt/CrowdStrike/falconctl -g --cid"
+    ansible.builtin.command: "/opt/CrowdStrike/falconctl -g --cid"
     register: cid_associated
     failed_when:
       - cid_associated.rc != 0
@@ -78,7 +73,7 @@
     changed_when: '"cid=" not in cid_associated.stdout'
 
   - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (Linux)
-    command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_cid }}"
+    ansible.builtin.command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_cid }}"
     when:
       - '"cid=" not in cid_associated.stdout'
       - not falcon_provisioning_token
@@ -88,7 +83,7 @@
       - ansible_distribution != "MacOSX"
 
   - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (macOS)
-    command: "/Applications/Falcon.app/Contents/Resources/falconctl license {{ falcon_cid }}"
+    ansible.builtin.command: "/Applications/Falcon.app/Contents/Resources/falconctl license {{ falcon_cid }}"
     when:
       - not falcon_provisioning_token
       - falcon_cid is defined
@@ -97,7 +92,7 @@
       - not falcon_already_installed.stat.exists
 
   - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) Using Provisioning Token
-    command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_cid }} --provisioning-token={{ falcon_provisioning_token }}"
+    ansible.builtin.command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_cid }} --provisioning-token={{ falcon_provisioning_token }}"
     when:
       - falcon_provisioning_token
       - falcon_cid is defined
@@ -106,7 +101,7 @@
       - ansible_distribution != "MacOSX"
 
   - name: CrowdStrike Falcon Installer | Starting Falcon Sensor Daemon (Linux)
-    service:
+    ansible.builtin.service:
       name: falcon-sensor
       state: "{{ falcon_service_state | default('started') }}"
       enabled: yes
@@ -116,7 +111,7 @@
       - installed_sensor in ansible_facts.packages
 
   - name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
-    command: "/opt/CrowdStrike/falconctl -d -f --aid"
+    ansible.builtin.command: "/opt/CrowdStrike/falconctl -d -f --aid"
     when:
       - falcon_remove_agent_id
       - falcon_cid is defined
@@ -124,6 +119,6 @@
       - ansible_distribution != "MacOSX"
 
   - name: CrowdStrike Falcon | Starting Falcon Sensor (macOS)
-    command: "launchctl {{ falcon_service_state | default('start') }} com.crowdstrike.falcond"
+    ansible.builtin.command: "launchctl {{ falcon_service_state | default('start') }} com.crowdstrike.falcond"
     when:
       - ansible_distribution == "MacOSX"

--- a/roles/falcon_installation/tasks/main.yml
+++ b/roles/falcon_installation/tasks/main.yml
@@ -1,35 +1,41 @@
 ---
 # tasks file for falcon_installation
 - block:
-    - include_tasks: preinstall.yml
+    - ansible.builtin.include_tasks: preinstall.yml
+      # noqa unnamed-task 502
 
 - block:
-    - include_tasks: url.yml
+    - ansible.builtin.include_tasks: url.yml
+      # noqa unnamed-task 502
   when:
     - falcon_install_method == "url"
     - ansible_os_family != "Windows"
 
 - block:
-    - include_tasks: api.yml
+    - ansible.builtin.include_tasks: api.yml
+      # noqa unnamed-task 502
   when:
     - falcon_install_method == "api"
     - ansible_os_family != "Windows"
 
 - block:
-    - include_tasks: win_api.yml
+    - ansible.builtin.include_tasks: win_api.yml
+      # noqa unnamed-task 502
   when:
     - falcon_install_method == "api"
     - ansible_os_family == "Windows"
 
 - block:
-    - include_tasks: install.yml
+    - ansible.builtin.include_tasks: install.yml
+      # noqa unnamed-task 502
   when:
     - ansible_os_family != "Windows"
   become: true
   become_user: root
 
 - block:
-    - include_tasks: win_install.yml
+    - ansible.builtin.include_tasks: win_install.yml
+      # noqa unnamed-task 502
   when:
     - ansible_os_family == "Windows"
   become: true

--- a/roles/falcon_installation/tasks/preinstall.yml
+++ b/roles/falcon_installation/tasks/preinstall.yml
@@ -1,48 +1,48 @@
 ---
 - block:
   - name: "CrowdStrike Falcon | Validate Required API URL Is Defined"
-    fail:
+    ansible.builtin.fail:
       msg: "falcon_cloud is not configured! Please configure falcon_cloud and re-run the installation again!"
     when: not falcon_cloud
 
   - name: "CrowdStrike Falcon | Validate CrowdStrike API Client ID Is Defined"
-    fail:
+    ansible.builtin.fail:
       msg: "falcon_client_id is not configured! Please configure falcon_client_id and re-run the installation again!"
     when: not falcon_client_id
 
   - name: "CrowdStrike Falcon | Validate CrowdStrike API Client Secret Is Defined"
-    fail:
+    ansible.builtin.fail:
       msg: "falcon_client_secret is not configured! Please configure falcon_client_secret and re-run the installation again!"
     when: not falcon_client_secret
 
   - name: "CrowdStrike Falcon | Validate CrowdStrike Falcon Sensor version is correctly set"
-    fail:
+    ansible.builtin.fail:
       msg: "falcon_sensor_version must be an integer between 0 and 5 inclusive!"
     when: falcon_sensor_version | int < 0 or falcon_sensor_version | int > 5
 
   when: falcon_install_method == "api"
 
 - name: "CrowdStrike Falcon | Configure Python Interpreter for older Linux OSes"
-  set_fact:
+  ansible.builtin.set_fact:
     ansible_python_interpreter: /usr/bin/python
   when: ansible_distribution == "Amazon"
 
 - name: "CrowdStrike Falcon | Determine if Endpoint Operating System Is RHEL, CentOS, or Oracle Linux"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: RHEL/CentOS/Oracle
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
   when: ansible_os_family == "RedHat"
 
 - name: "CrowdStrike Falcon | Determine if Target OS Is Amazon Linux"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "Amazon Linux"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
   when: ansible_distribution == "Amazon"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Debian"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "9/10"
@@ -50,7 +50,7 @@
     - ansible_distribution == "Debian"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is SLES"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
@@ -58,7 +58,7 @@
     - ansible_distribution == "SLES"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Ubuntu"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "16/18/20"
@@ -66,7 +66,7 @@
     - ansible_distribution == "Ubuntu"
 
 - name: CrowdStrike Falcon | Determine if Target OS Is MacOS
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "macOS"
     falcon_os_family: "mac"
     falcon_path: "/Applications/Falcon.app/Contents/Resources/"
@@ -74,21 +74,21 @@
   when: ansible_distribution == "MacOSX"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Microsoft Windows"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_target_os: "{{ ansible_os_family }}"
     falcon_os_family: "{{ ansible_os_family | lower }}"
     falcon_os_version: ""
   when: ansible_os_family == "Windows"
 
 - name: CrowdStrike Falcon | Set default sensor name
-  set_fact:
+  ansible.builtin.set_fact:
     installed_sensor: falcon-sensor
   when:
     - ansible_pkg_mgr is defined
     - ansible_pkg_mgr in linux_packagers
 
 - name: CrowdStrike Falcon | Set default sensor name for non-Windows installations
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ installed_sensor }}"
   when:
     - ansible_pkg_mgr is defined
@@ -96,7 +96,7 @@
     - falcon_sensor_download is not defined
 
 - name: CrowdStrike Falcon | Verify Temporary Install Directory Exists (non-Windows)
-  file: # noqa: risky-file-permissions,208      # We shouldn't try to change permissions if /tmp is used
+  ansible.builtin.file: # noqa: risky-file-permissions,208      # We shouldn't try to change permissions if /tmp is used
     path: "{{ falcon_install_tmp_dir }}"
     state: directory
   when:
@@ -104,7 +104,7 @@
     - falcon_install_tmp_dir is defined
 
 - name: CrowdStrike Falcon | Verify Temporary Install Directory Exists (Windows)
-  win_file: # noqa: risky-file-permissions,208      # We shouldn't try to change permissions if /tmp is used
+  ansible.windows.win_file: # noqa: risky-file-permissions,208      # We shouldn't try to change permissions if /tmp is used
     path: "{{ falcon_windows_tmp_dir }}"
     state: directory
   when:
@@ -112,7 +112,7 @@
     - falcon_windows_tmp_dir is defined
 
 - name: CrowdStrike Falcon | Verify Falcon is not already installed (macOS)
-  stat:
+  ansible.builtin.stat:
     path: "{{ falcon_path }}"
   when:
     - ansible_system == "Darwin"
@@ -120,7 +120,7 @@
   register: falcon_already_installed
 
 - name: CrowdStrike Falcon | Set service state for Primary Images
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_service_state: stopped
   when:
     - falcon_remove_agent_id

--- a/roles/falcon_installation/tasks/url.yml
+++ b/roles/falcon_installation/tasks/url.yml
@@ -1,7 +1,7 @@
 ---
 # Tasks for Installing CrowdStrike's Falcon Sensor via URL
 - name: CrowdStrike Falcon | Downloading Installation Package from URL
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ falcon_download_url }}"
     dest: "{{ falcon_install_tmp_dir }}"
   when:
@@ -13,5 +13,5 @@
   until: falcon_sensor_download is success
 
 - name: CrowdStrike Falcon | Set full file download path
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ falcon_sensor_download.dest }}"

--- a/roles/falcon_installation/tasks/win_api.yml
+++ b/roles/falcon_installation/tasks/win_api.yml
@@ -1,6 +1,6 @@
 ---
 - name: CrowdStrike Falcon | Authenticate to CrowdStrike API
-  win_uri:
+  ansible.windows.win_uri:
     url: "https://{{ falcon_cloud }}/oauth2/token"
     method: POST
     body: "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
@@ -11,7 +11,7 @@
   register: falcon_api_oauth2_token
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
-  win_uri:
+  ansible.windows.win_uri:
     url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
     method: GET
     return_content: true
@@ -25,7 +25,7 @@
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
-  win_uri:
+  ansible.windows.win_uri:
     url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"
     method: GET
     return_content: true
@@ -34,11 +34,8 @@
       Content-Type: application/json
   register: falcon_api_installer_list
 
-- debug:
-    msg: "{{ falcon_api_installer_list.json.resources[0] }}"
-
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_api_installer_list.json.resources[falcon_sensor_version | int].sha256 }}"
     dest: "{{ falcon_windows_tmp_dir }}\\{{ falcon_api_installer_list.json.resources[falcon_sensor_version | int].name }}"
     checksum: "{{ falcon_api_installer_list.json.resources[0].sha256 }}"
@@ -48,10 +45,10 @@
   register: falcon_sensor_download
 
 - name: CrowdStrike Falcon | Set CID received from API
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"
   when: not falcon_cid
 
 - name: CrowdStrike Falcon | Set full file download path
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ falcon_sensor_download.dest }}"

--- a/roles/falcon_installation/tasks/win_install.yml
+++ b/roles/falcon_installation/tasks/win_install.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: CrowdStrike Falcon | Install Falcon Sensor .exe Package (Windows)
-    win_package:
+    ansible.windows.win_package:
       path: "{{ falcon_sensor_pkg }}"
       state: present
       creates_service: csfalconservice
@@ -14,7 +14,7 @@
     until: falcon_installed is success
 
   - name: CrowdStrike Falcon Installer | Starting Falcon Sensor Service (Windows)
-    win_service:
+    ansible.windows.win_service:
       name: csfalconservice
       state: "{{ falcon_service_state | default('started') }}"
       start_mode: auto
@@ -22,7 +22,7 @@
       - falcon_cid is defined
 
   - name: CrowdStrike Falcon Installer | Remove any AID Key
-    win_regedit:
+    ansible.windows.win_regedit:
       path: "{{ item }}"
       state: absent
       delete_key: true

--- a/roles/falcon_uninstall/tasks/uninstall.yml
+++ b/roles/falcon_uninstall/tasks/uninstall.yml
@@ -1,12 +1,12 @@
 ---
 - name: CrowdStrike Falcon | Determine if Falcon is installed (MacOS)
-  stat:
+  ansible.builtin.stat:
     path: "/Applications/Falcon.app/Contents/Resources/falconctl"
   when: ansible_distribution == "MacOSX"
   register: falcon_already_installed
 
 - name: CrowdStrike Falcon | Uninstalling Falcon Sensor (Linux)
-  package:
+  ansible.builtin.package:
     name: falcon-sensor
     state: absent
   when:
@@ -14,11 +14,11 @@
 
 - block:
     - name: CrowdStrike Falcon | Stopping Falcon Sensor (macOS)
-      command: "launchctl stop com.crowdstrike.falcond"
+      ansible.builtin.command: "launchctl stop com.crowdstrike.falcond"
       when: falcon_already_installed.stat.exists
 
     - name: CrowdStrike Falcon | Uninstalling Falcon Sensor (macOS)
-      command: "/Applications/Falcon.app/Contents/Resources/falconctl uninstall"
+      ansible.builtin.command: "/Applications/Falcon.app/Contents/Resources/falconctl uninstall"
       when: falcon_already_installed.stat.exists
   when:
     - falcon_already_installed is defined

--- a/roles/falcon_uninstall/tasks/win_uninstall.yml
+++ b/roles/falcon_uninstall/tasks/win_uninstall.yml
@@ -1,14 +1,14 @@
 ---
 - block:
   - name: CrowdStrike Falcon | Find Windows installer in Package Cache
-    win_find:
+    ansible.windows.win_find:
       paths: C:\ProgramData\Package Cache
       patterns: WindowsSensor.exe
       recurse: yes
     register: falcon_win_sensor_cache
 
   - name: CrowdStrike Falcon | Remove Falcon Sensor (Windows)
-    win_package:
+    ansible.windows.win_package:
       path: "{{ falcon_win_sensor_cache.files[0].path }}"
       state: absent
       creates_service: csfalconservice

--- a/tests/ansible-lint.conf
+++ b/tests/ansible-lint.conf
@@ -1,3 +1,6 @@
+enable_list:
+  - fqcn-builtins  # opt-in
+
 skip_list:
   - '204'
   - experimental  # all rules tagged as experimental


### PR DESCRIPTION
- Recommended by Ansible to avoid using external collections that might have the same name