### PR TITLE
Gives the ability to specify a sensor update policy

### DIFF
--- a/roles/falcon_installation/README.md
+++ b/roles/falcon_installation/README.md
@@ -1,7 +1,7 @@
 Installation
 =========
 
-This role will install or uninstall the CrowdStrike Falcon Sensor.
+This role will install the CrowdStrike Falcon Sensor.
 
 Requirements
 ------------
@@ -24,6 +24,7 @@ The following variables are currently supported:
  * `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: null)
  * `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: null)
  * `falcon_sensor_version` - Sensor version to install (int, default: 0 [latest])
+ * `falcon_sensor_update_policy_name` - Sensor update policy used to control sensor version (string, default: null)
  * `falcon_install_tmp_dir` - Temporary Linux and MacOS download and installation directory for the Falson Sensor (string, default: `/tmp/`)
  * `falcon_download_url` - URL for downloading the sensor (string, default: null)
  * `falcon_retries` - Number of attempts to download the sensor (int, default: 3)
@@ -46,7 +47,7 @@ Privilege escalation (sudo) is required for this role to function properly.
 Example Playbooks
 ----------------
 
-This example installs the Falcon Sensor:
+This example installs the latest Falcon Sensor:
 
 ```yaml
 ---
@@ -57,7 +58,30 @@ This example installs the Falcon Sensor:
     falcon_client_id: <Falcon_UI_OAUTH_client_id>
     falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
 ```
-
+---
+This example installs the Falcon Sensor at version N-2:
+```yaml
+---
+- hosts: all
+  roles:
+  - role: crowdstrike.falcon.falcon_installation
+  vars:
+    falcon_client_id: <Falcon_UI_OAUTH_client_id>
+    falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
+    falcon_sensor_version: 2
+```
+---
+This example installs the Falcon Sensor using a sensor update policy called "ACME Policy":
+```yaml
+---
+- hosts: all
+  roles:
+  - role: crowdstrike.falcon.falcon_installation
+  vars:
+    falcon_client_id: <Falcon_UI_OAUTH_client_id>
+    falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
+    falcon_sensor_update_policy_name: "ACME Policy"
+```
 License
 -------
 
@@ -66,4 +90,4 @@ License
 Author Information
 ------------------
 
-CrowdStrike Solutions Architects
+CrowdStrike Solution Architects

--- a/roles/falcon_installation/defaults/main.yml
+++ b/roles/falcon_installation/defaults/main.yml
@@ -59,6 +59,15 @@ falcon_client_secret: ""
 #
 falcon_sensor_version: 0
 
+# The name of the Falcon Sensor Update Policy to use in order to specify the Falcon sensor
+# version to install. This is optional, however, if specified, please note that this will
+# override the falcon_sensor_version variable.
+#
+# Note: To use the default Falcon Sensor update policy:
+#   falcon_sensor_update_policy_name: "platform_default"
+#
+falcon_sensor_update_policy_name: ""
+
 # Where should the sensor file be downloaded to on Linux and MacOS systems?
 # By default, this will be the temp OS filesystem
 #

--- a/roles/falcon_installation/tasks/api.yml
+++ b/roles/falcon_installation/tasks/api.yml
@@ -25,15 +25,15 @@
 # Block when falcon_sensor_update_policy_name is supplied
 - block:
   - name: "CrowdStrike Falcon | Override falcon_sensor_version when falcon_sensor_update_policy_name supplied"
-    set_fact:
+    ansible.builtin.set_fact:
       falcon_sensor_version: 0
 
   - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
-    set_fact:
+    ansible.builtin.set_fact:
       falcon_sensor_update_policy_query: "{{ 'platform_name:\"' + falcon_sensor_update_policy_platform + '\"+name.raw:\"' + falcon_sensor_update_policy_name + '\"' }}"
 
   - name: "CrowdStrike Falcon | Search for Sensor Update Policy"
-    uri:
+    ansible.builtin.uri:
       url: "https://{{ falcon_cloud }}/policy/combined/sensor-update/v2?filter={{ falcon_sensor_update_policy_query | urlencode }}"
       method: GET
       return_content: true
@@ -43,22 +43,22 @@
     register: falcon_sensor_update_policy_info
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
-    fail:
+    ansible.builtin.fail:
       msg: "No Falcon Sensor Update Policy with name: {{ falcon_sensor_update_policy_name }} was found!"
     when: falcon_sensor_update_policy_info.json.resources[0] is not defined
 
   - name: "CrowdStrike Falcon | Get the Falcon Sensor version from Update Policy"
-    set_fact:
+    ansible.builtin.set_fact:
       falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.json.resources[0].settings.sensor_version }}"
 
   - name: "CrowdStrike Falcon | Build API Query"
-    set_fact:
+    ansible.builtin.set_fact:
       falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_update_policy_package_version + '\"' }}"
 
   when: falcon_sensor_update_policy_name
 
 - name: "CrowdStrike Falcon | Build API Query"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
   when: not falcon_sensor_update_policy_name
 

--- a/roles/falcon_installation/tasks/api.yml
+++ b/roles/falcon_installation/tasks/api.yml
@@ -22,9 +22,45 @@
       Content-Type: application/json
   register: falcon_api_target_cid
 
+# Block when falcon_sensor_update_policy_name is supplied
+- block:
+  - name: "CrowdStrike Falcon | Override falcon_sensor_version when falcon_sensor_update_policy_name supplied"
+    set_fact:
+      falcon_sensor_version: 0
+
+  - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
+    set_fact:
+      falcon_sensor_update_policy_query: "{{ 'platform_name:\"' + falcon_sensor_update_policy_platform + '\"+name.raw:\"' + falcon_sensor_update_policy_name + '\"' }}"
+
+  - name: "CrowdStrike Falcon | Search for Sensor Update Policy"
+    uri:
+      url: "https://{{ falcon_cloud }}/policy/combined/sensor-update/v2?filter={{ falcon_sensor_update_policy_query | urlencode }}"
+      method: GET
+      return_content: true
+      headers:
+        authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+        Content-Type: application/json
+    register: falcon_sensor_update_policy_info
+
+  - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
+    fail:
+      msg: "No Falcon Sensor Update Policy with name: {{ falcon_sensor_update_policy_name }} was found!"
+    when: falcon_sensor_update_policy_info.json.resources[0] is not defined
+
+  - name: "CrowdStrike Falcon | Get the Falcon Sensor version from Update Policy"
+    set_fact:
+      falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.json.resources[0].settings.sensor_version }}"
+
+  - name: "CrowdStrike Falcon | Build API Query"
+    set_fact:
+      falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_update_policy_package_version + '\"' }}"
+
+  when: falcon_sensor_update_policy_name
+
 - name: "CrowdStrike Falcon | Build API Query"
   set_fact:
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
+  when: not falcon_sensor_update_policy_name
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
   ansible.builtin.uri:

--- a/roles/falcon_installation/tasks/preinstall.yml
+++ b/roles/falcon_installation/tasks/preinstall.yml
@@ -32,6 +32,7 @@
     falcon_target_os: RHEL/CentOS/Oracle
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
+    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
   when: ansible_os_family == "RedHat"
 
 - name: "CrowdStrike Falcon | Determine if Target OS Is Amazon Linux"
@@ -39,6 +40,7 @@
     falcon_target_os: "Amazon Linux"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
+    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
   when: ansible_distribution == "Amazon"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Debian"
@@ -46,6 +48,7 @@
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "9/10"
+    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
   when:
     - ansible_distribution == "Debian"
 
@@ -54,6 +57,7 @@
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
+    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
   when:
     - ansible_distribution == "SLES"
 
@@ -62,6 +66,7 @@
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "16/18/20"
+    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
   when:
     - ansible_distribution == "Ubuntu"
 
@@ -71,6 +76,7 @@
     falcon_os_family: "mac"
     falcon_path: "/Applications/Falcon.app/Contents/Resources/"
     falcon_os_version: ""
+    falcon_sensor_update_policy_platform: "{{ falcon_os_family | capitalize }}"
   when: ansible_distribution == "MacOSX"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Microsoft Windows"
@@ -78,6 +84,7 @@
     falcon_target_os: "{{ ansible_os_family }}"
     falcon_os_family: "{{ ansible_os_family | lower }}"
     falcon_os_version: ""
+    falcon_sensor_update_policy_platform: "{{ ansible_os_family }}"
   when: ansible_os_family == "Windows"
 
 - name: CrowdStrike Falcon | Set default sensor name
@@ -100,7 +107,7 @@
     path: "{{ falcon_install_tmp_dir }}"
     state: directory
   when:
-    - ansible_os_family == "Linux" or ansible_system == "Darwin"
+    - ansible_system == "Linux" or ansible_system == "Darwin"
     - falcon_install_tmp_dir is defined
 
 - name: CrowdStrike Falcon | Verify Temporary Install Directory Exists (Windows)

--- a/roles/falcon_installation/tasks/win_api.yml
+++ b/roles/falcon_installation/tasks/win_api.yml
@@ -21,7 +21,7 @@
   register: falcon_api_target_cid
 
 - name: "CrowdStrike Falcon | Build API Query"
-  set_fact:
+  ansible.builtin.set_fact:
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors

--- a/roles/falcon_installation/tasks/win_api.yml
+++ b/roles/falcon_installation/tasks/win_api.yml
@@ -20,9 +20,45 @@
       Content-Type: application/json
   register: falcon_api_target_cid
 
+# Block when falcon_sensor_update_policy_name is supplied
+- block:
+  - name: "CrowdStrike Falcon | Override falcon_sensor_version when falcon_sensor_update_policy_name supplied"
+    ansible.builtin.set_fact:
+      falcon_sensor_version: 0
+
+  - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
+    ansible.builtin.set_fact:
+      falcon_sensor_update_policy_query: "{{ 'platform_name:\"' + falcon_sensor_update_policy_platform + '\"+name.raw:\"' + falcon_sensor_update_policy_name + '\"' }}"
+
+  - name: "CrowdStrike Falcon | Search for Sensor Update Policy"
+    ansible.windows.win_uri:
+      url: "https://{{ falcon_cloud }}/policy/combined/sensor-update/v2?filter={{ falcon_sensor_update_policy_query | urlencode }}"
+      method: GET
+      return_content: true
+      headers:
+        authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+        Content-Type: application/json
+    register: falcon_sensor_update_policy_info
+
+  - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
+    ansible.builtin.fail:
+      msg: "No Falcon Sensor Update Policy with name: {{ falcon_sensor_update_policy_name }} was found!"
+    when: falcon_sensor_update_policy_info.json.resources[0] is not defined
+
+  - name: "CrowdStrike Falcon | Get the Falcon Sensor version from Update Policy"
+    ansible.builtin.set_fact:
+      falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.json.resources[0].settings.sensor_version }}"
+
+  - name: "CrowdStrike Falcon | Build API Query"
+    ansible.builtin.set_fact:
+      falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_update_policy_package_version + '\"' }}"
+
+  when: falcon_sensor_update_policy_name
+
 - name: "CrowdStrike Falcon | Build API Query"
   ansible.builtin.set_fact:
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
+  when: not falcon_sensor_update_policy_name
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
   ansible.windows.win_uri:

--- a/roles/falcon_uninstall/README.md
+++ b/roles/falcon_uninstall/README.md
@@ -46,4 +46,4 @@ License
 Author Information
 ------------------
 
-CrowdStrike Solutions Architects
+CrowdStrike Solution Architects


### PR DESCRIPTION
Fixes #61 

- Added more examples in the README
- Added the ability to specify a sensor update policy name to manage what version of the falcon sensor gets installed
- minor fixes to README and preinstall.yml