### PR TITLE
Enable pull_request_target + molecule changes

### DIFF
--- a/.github/workflows/falcon_installation.yml
+++ b/.github/workflows/falcon_installation.yml
@@ -5,7 +5,7 @@ on:
       - 'roles/falcon_installation/**'
       - 'molecule/falcon_installation/**'
       - '.github/workflows/falcon_installation.yml'
-  pull_request:
+  pull_request_target:
     paths:
       - 'roles/falcon_installation/**'
       - 'molecule/falcon_installation/**'

--- a/molecule/falcon_installation/cleanup.yml
+++ b/molecule/falcon_installation/cleanup.yml
@@ -1,0 +1,4 @@
+- name: Cleanup
+  hosts: all
+  roles:
+    - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/falcon_installation/molecule.yml
+++ b/molecule/falcon_installation/molecule.yml
@@ -19,3 +19,17 @@ lint: |
   set -e
   yamllint .
   ansible-lint .
+scenario:
+  test_sequence:
+    - dependency
+    - lint
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy


### PR DESCRIPTION
This PR allows the use of the `pull_request_target`, enabling us to run the Molecule testing using the GH secrets. I've also added the changes to Molecule to allow testing of the uninstall_role inside the installation_role