### PR TITLE
Added changed_when clause to support idempotency

### DIFF
--- a/roles/falcon_installation/tasks/install.yml
+++ b/roles/falcon_installation/tasks/install.yml
@@ -62,6 +62,7 @@
       path: "{{ falcon_install_temp_directory.path }}"
       state: absent
     when: falcon_install_temp_directory.path is defined
+    changed_when: no
 
   - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (Linux)
     crowdstrike.falcon.falconctl:

--- a/roles/falcon_installation/tasks/preinstall.yml
+++ b/roles/falcon_installation/tasks/preinstall.yml
@@ -101,6 +101,7 @@
     - ansible_system == "Linux" or ansible_system == "Darwin"
     - falcon_install_tmp_dir is defined
   register: falcon_install_temp_directory
+  changed_when: no
 
 - name: CrowdStrike Falcon | Verify Temporary Install Directory Exists (Windows)
   ansible.windows.win_tempfile:
@@ -111,6 +112,7 @@
     - ansible_os_family == "Windows"
     - falcon_windows_tmp_dir is defined
   register: falcon_install_win_temp_directory
+  changed_when: no
 
 - name: CrowdStrike Falcon | Verify Falcon is not already installed (macOS)
   ansible.builtin.stat:

--- a/roles/falcon_installation/tasks/win_install.yml
+++ b/roles/falcon_installation/tasks/win_install.yml
@@ -18,6 +18,7 @@
       path: "{{ falcon_install_win_temp_directory.path }}"
       state: absent
     when: falcon_install_win_temp_directory.path is defined
+    changed_when: no
 
   - name: CrowdStrike Falcon Installer | Starting Falcon Sensor Service (Windows)
     ansible.windows.win_service:


### PR DESCRIPTION
The default behavior for tempfile is to not be idempotent, especially when created and removed. This change ignores the changes, allowing it to appear "idempotent".