### PR TITLE
Merged falcon_configure options tasks + minor fixes

### DIFF
--- a/molecule/falcon_configure/converge.yml
+++ b/molecule/falcon_configure/converge.yml
@@ -8,7 +8,6 @@
         falcon_cid: "{{ lookup('env', 'FALCON_CID') }}"
         falcon_provisioning_token: '12345678'
         falcon_tags: 'falcon,example,tags'
-        falcon_metadata_query: 'enableAWS,disableGCP'
         falcon_billing: 'metered'
         falcon_message_log: yes
         falcon_feature:

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -15,24 +15,30 @@
         - info.falconctl_info.cid
         - info.falconctl_info.billing
         - info.falconctl_info.tags
-        - info.falconctl_info.metadata_query
         - info.falconctl_info.message_log
         - not info.falconctl_info.apd
         - not info.falconctl_info.aph
         - not info.falconctl_info.app
         - not info.falconctl_info.trace
 
-  - name: Test removing AID
-    crowdstrike.falcon.falconctl:
-      aid: yes
-      state: absent
+  - name: Test Deleting Options
+    ansible.builtin.include_role:
+      name: crowdstrike.falcon.falcon_configure
+    vars:
+      falcon_option_set: no
+      falcon_remove_aid: yes
+      falcon_cid: ""
+      falcon_tags: ""
+      falcon_billing: ""
 
-  - name: Get AID Falcon Sensor Option
+  - name: Get Updated Falcon Sensor Option
     crowdstrike.falcon.falconctl_info:
-      name: 'aid'
-    register: aid
+    register: delete
 
   - name: Verify AID Falcon Sensor options is not set
     ansible.builtin.assert:
       that:
-        - not aid.falconctl_info.aid
+        - not delete.falconctl_info.aid
+        - not delete.falconctl_info.cid
+        - not delete.falconctl_info.tags
+        - not delete.falconctl_info.billing

--- a/plugins/modules/falconctl.py
+++ b/plugins/modules/falconctl.py
@@ -65,10 +65,6 @@ options:
       type: list
       elements: str
       choices: [ none, enableLog, disableLogBuffer ]
-    metadata_query:
-      description:
-        - Configure the Falcon sensor cloud provider metadata query flags.
-      type: str
     message_log:
       description:
         - Whether or not you would like to log messages to disk.
@@ -82,7 +78,6 @@ options:
         - For ephemeral workloads in these cloud environments, you pay only for the hours that hosts
           are active each month C(metered), rather than a full annual contract price per sensor C(default).
       type: str
-      choices: [ default, metered ]
     tags:
       description:
         - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts.
@@ -145,7 +140,6 @@ VALID_PARAMS = {
         "app",
         "trace",
         "feature",
-        "metadata_query",
         "message_log",
         "billing",
         "tags",
@@ -187,7 +181,7 @@ class FalconCtl(object):
         """Converts paramaters passed as lists to strings"""
         if isinstance(value, list):
             # Make a copy and return it
-            new_value = value.copy()
+            new_value = value[:]
             return ','.join(new_value)
         return value
 
@@ -213,7 +207,7 @@ class FalconCtl(object):
         args = [self.falconctl, "-%s" % fstate, "-f"]
 
         for k in self.params:
-            if self.params[k]:
+            if self.params[k] or self.params[k] == "":
                 if k in self.valid_params[fstate]:
                     key = k.replace("_", "-")
                     if state == "present":
@@ -240,17 +234,20 @@ class FalconCtl(object):
         if key == "cid":
             # Get the 32 chars in lowercase
             return value.lower()[:32]
-        # Deal with list valueions
+        # Deal with message_log
+        if key == "message_log":
+            return value.lower()
+        # Deal with list evaluations
         if isinstance(value, list):
             if key == "feature":
                 if 'none' in value and len(value) > 1:
                     # remove none from list by making copy, to keep orig intact
-                    new_list = value.copy()
+                    new_list = value[:]
                     new_list.remove('none')
                     return self.__list_to_string(new_list)
             return self.__list_to_string(value)
 
-        # return value if isinstance(value, bool) else value.lower()
+        # return value
         return value
 
     def check_mode(self, before):
@@ -285,15 +282,6 @@ class FalconCtl(object):
 
     def validate_params(self, params):
         """Check parameters that are conditionally required"""
-        if params["metadata_query"]:
-            choices_str = ["enable", "disable"]
-            choices_list = ["enableAWS", "enableAzure", "enableGCP",
-                            "disableAWS", "disableAzure", "disableGCP"]
-            mq = params["metadata_query"]
-            if mq not in choices_str and \
-                    not all(item in choices_list for item in mq.split(",")):
-                self.module.fail_json(
-                    msg="value of %s must be one of: enable, disable, got: %s" % ("metadata_query", mq))
 
         if params["provisioning_token"]:
             # Ensure cid is also passed
@@ -307,6 +295,12 @@ class FalconCtl(object):
             if not valid_token:
                 self.module.fail_json(
                     msg="Invalid provisioning token: '%s'" % (params["provisioning_token"]))
+
+        if params["billing"]:
+            valid_choices = ["default", "metered"]
+            if params["billing"] not in valid_choices:
+                self.module.fail_json(
+                    msg="Value of billing must be one of: default|metered, got %s" % (params["billing"]))
 
         if params["cid"]:
             valid_cid = self.__validate_regex(
@@ -336,11 +330,9 @@ def main():  # pylint: disable=missing-function-docstring
         trace=dict(required=False, choices=[
                    "none", "err", "warn", "info", "debug"], type="str"),
         feature=dict(required=False, choices=[
-            "none", "enableLog", "disableLogBuffer"], type="list", elements='str'),
-        metadata_query=dict(required=False, type="str"),
+            "none", "enableLog", "disableLogBuffer"], type="list", elements="str"),
         message_log=dict(required=False, choices=["True", "true", "False", "false"], type="str"),
-        billing=dict(required=False, choices=[
-                     "default", "metered"], type="str"),
+        billing=dict(required=False, type="str"),
         tags=dict(required=False, type="str"),
     )
 

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -20,7 +20,6 @@ Role Variables
  * `falcon_app` - Falcon Proxy port (int, default: null)
  * `falcon_trace` - Configure additional traces for debugging (string, default: null)
  * `falcon_feature` - Configures additional features to the sensor (list, default: null)
- * `falcon_metadata_query` - Enables additional sensor support in cloud environments (string, default: null)
  * `falcon_message_log` - Enables|Disables message logs (string, default: null)
  * `falcon_billing` - Configure Falcon sensor with Pay-As-You-Go billing (string, default: null)
  * `falcon_tags` - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts (string, default: null)
@@ -39,7 +38,6 @@ Role Variables
 | falcon_app                | S/D   |
 | falcon_trace              | S/D   |
 | falcon_feature            | S     |
-| falcon_metadata_query     | S     |
 | falcon_message_log        | S     |
 | falcon_billing            | S/D   |
 | falcon_tags               | S/D   |
@@ -89,7 +87,6 @@ This example shows how to set some of the other options:
   - role: crowdstrike.falcon.falcon_configure
     vars:
       falcon_tags: 'falcon,example,tags'
-      falcon_metadata_query: 'enableAWS,disableGCP'
       falcon_billing: 'metered'
       falcon_message_log: yes
 ```

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -43,24 +43,15 @@ falcon_app:
 falcon_trace:
 
 # Falcon allows the configuration of additional features to the sensor. Valid values are:
-# [none,[enableLog[,disableLogBuffer[,disableOsfm[,emulateUpdate]]]]] and are passed in as
+# [none,[enableLog[,disableLogBuffer]]] and are passed in as
 # a list.
 #
 # Example
 #   falcon_feature:
 #     - enableLog
-#     - emulateUpdate
+#     - disableLogBuffer
 #
 falcon_feature:
-
-# Falcon sensor allows additional cloud provider metadata query support. Valid values are:
-# [[dis|en]able|[dis|en]ableAWS[,[dis|en]ableAzure[,[dis|en]ableGCP]]].
-#
-# Example(s)
-#   falcon_metadata_query: 'enable'
-#   falcon_metadata_query: 'enableAWS,disableAzure,enableGCP'
-#
-falcon_metadata_query:
 
 # Whether to enable or disable the ability to log messages to disk. Set this value to either
 # 'true|yes' or 'false|no'.

--- a/roles/falcon_configure/handlers/main.yml
+++ b/roles/falcon_configure/handlers/main.yml
@@ -3,4 +3,5 @@
   - name: CrowdStrike Falcon | Restart Falcon Sensor
     ansible.builtin.service:
       name: falcon-sensor
-      state: "{{ falcon_service_state | default('restarted') }}"
+      state: restarted
+    when: info.falconctl_info.cid

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -1,13 +1,7 @@
 ---
 # Linux block
 - block:
-  - name: CrowdStrike Falcon | Set service state for Primary Images
-    ansible.builtin.set_fact:
-      falcon_service_state: stopped
-    when:
-      - falcon_remove_aid
-
-  - name: CrowdStrike Falcon | Set Falcon Sensor Options (Linux)
+  - name: CrowdStrike Falcon | Configure Falcon Sensor Options (Linux)
     crowdstrike.falcon.falconctl:
       cid: "{{ falcon_cid if (falcon_cid != None) else omit }}"
       provisioning_token: "{{ falcon_provisioning_token if (falcon_provisioning_token != None) else omit }}"
@@ -16,27 +10,15 @@
       app: "{{ falcon_app if (falcon_app != None) else omit }}"
       trace: "{{ falcon_trace if (falcon_trace != None) else omit }}"
       feature: "{{ falcon_feature if (falcon_feature != None) else omit }}"
-      metadata_query: "{{ falcon_metadata_query if (falcon_metadata_query != None) else omit }}"
       message_log: "{{ falcon_message_log if (falcon_message_log != None) else omit }}"
       billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
       tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
-      state: present
+      state: "{{ 'present' if falcon_option_set else 'absent' }}"
     notify: CrowdStrike Falcon | Restart Falcon Sensor
-    when: falcon_option_set
 
-  - name: CrowdStrike Falcon | Delete Falcon Sensor Options (Linux)
-    crowdstrike.falcon.falconctl:
-      cid: "{{ falcon_cid if (falcon_cid != None) else omit }}"
-      provisioning_token: "{{ falcon_provisioning_token if (falcon_provisioning_token != None) else omit }}"
-      apd: "{{ falcon_apd if (falcon_apd != None) else omit }}"
-      aph: "{{ falcon_aph if (falcon_aph != None) else omit }}"
-      app: "{{ falcon_app if (falcon_app != None) else omit }}"
-      trace: "{{ falcon_trace if (falcon_trace != None) else omit }}"
-      billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
-      tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
-      state: absent
-    notify: CrowdStrike Falcon | Restart Falcon Sensor
-    when: not falcon_option_set
+  - name: CrowdStrike Falcon | Register Falcon Sensor Options
+    crowdstrike.falcon.falconctl_info:
+    register: info
 
   - name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
     crowdstrike.falcon.falconctl:


### PR DESCRIPTION
closes #110 
This PR fixes:

- Removal of `--metadata-query` falconctl options (not supported at this time)
- Adds better test support for molecule verify stage
- Fixes bug in `add_args` function dealing with empty strings which are useful and valid for delete operations
- Fixed bug with `--message-log` needing to be lowercased to match get option value
- Added `--billing` param validation
- Added functionality/error-handling around the `falcon_configure` role handler. The falcon-sensor can't restart when no CID is attached. 