### PR TITLE
Adding autodetect cid feature to configure role

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ collections:
   - crowdstrike.falcon
 ```
 
+#### Example Playbook
+Install and configure the CS Falcon Sensor at version N-2:
+```yaml
+- hosts: all
+  vars:
+    falcon_client_id: <Falcon_UI_OAUTH_client_id>
+    falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
+  roles:
+  - role: crowdstrike.falcon.falcon_install
+    vars:
+      falcon_sensor_version_decrement: 2
+  - role: crowdstrike.falcon.falcon_configure
+    vars:
+      # falcon_cid is autodetected using falcon_client_id|secret vars
+      falcon_tags: 'falcon,example,tags'
+```
 
 ## Installing on MacOS
 

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -33,12 +33,28 @@
 
   - name: Get Updated Falcon Sensor Option
     crowdstrike.falcon.falconctl_info:
-    register: delete
+    register: delete_info
 
   - name: Verify AID Falcon Sensor options is not set
     ansible.builtin.assert:
       that:
-        - not delete.falconctl_info.aid
-        - not delete.falconctl_info.cid
-        - not delete.falconctl_info.tags
-        - not delete.falconctl_info.billing
+        - not delete_info.falconctl_info.aid
+        - not delete_info.falconctl_info.cid
+        - not delete_info.falconctl_info.tags
+        - not delete_info.falconctl_info.billing
+
+  - name: Test auto-detecting CID
+    ansible.builtin.include_role:
+      name: crowdstrike.falcon.falcon_configure
+    vars:
+      falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+      falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+
+  - name: Get CID Option
+    crowdstrike.falcon.falconctl_info:
+      name: 'cid'
+    register: autodetect_info
+
+  - name: Verify CID was configured
+    ansible.builtin.assert:
+      that: autodetect_info.falconctl_info.cid

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -12,7 +12,9 @@ Role Variables
 --------------
 
  * `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
- * `falcon_cid` - Your Falcon Customer ID (CID) (string, default: null)
+ * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
+ * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)
+ * `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: null)
  * `falcon_provisioning_token` - Falcon Installation Token (string, default: null)
  * `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: null)
  * `falcon_apd` - Whether to enable or disable the Falcon sensor to use a proxy (string, default: null)
@@ -46,17 +48,28 @@ Dependencies
 ------------
 
 - Privilege escalation (sudo) is required for this role to function properly.
+- Falcon Sensor must be installed
 
 Example Playbook
 ----------------
 
-How to set the Falcon Customer ID (CID):
+How to set the Falcon Customer ID (CID) when CID is known:
 ```yaml
 - hosts: all
   roles:
   - role: crowdstrike.falcon.falcon_configure
     vars:
       falcon_cid: 1234567890ABCDEF1234567890ABCDEF-12
+```
+
+How to set the Falcon Customer ID (CID) using API creds:
+```yaml
+- hosts: all
+  roles:
+  - role: crowdstrike.falcon.falcon_configure
+    vars:
+      falcon_client_id: <Falcon_UI_OAUTH_client_id>
+      falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
 ```
 
 How to set the Falcon Customer ID (CID) w/ provisioning token:

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -6,6 +6,14 @@ falcon_option_set: yes
 #
 falcon_cid:
 
+# 'Client ID' and 'Client Secret' for authentication against the CrowdStrike
+# API. If unknown, get it from the CrowdStrike support portal:
+#
+#   https://falcon.crowdstrike.com/support/api-clients-and-keys
+#
+falcon_client_id:
+falcon_client_secret:
+
 # Installation tokens prevent unauthorized hosts from being accidentally or maliciously added
 # to your Customer ID (CID). Installation tokens are an optional security
 # measure for your CID. For more details:

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -1,0 +1,27 @@
+---
+- name: CrowdStrike Falcon | Authenticate to CrowdStrike API
+  ansible.builtin.uri:
+    url: "https://{{ falcon_cloud }}/oauth2/token"
+    method: POST
+    body_format: json
+    body:
+      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
+    return_content: true
+    status_code: 201
+    headers:
+      content-type: application/x-www-form-urlencoded
+  register: falcon_api_oauth2_token
+
+- name: CrowdStrike Falcon | Detect Target CID Based on Credentials
+  ansible.builtin.uri:
+    url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
+    method: GET
+    return_content: true
+    headers:
+      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+      Content-Type: application/json
+  register: falcon_api_target_cid
+
+- name: CrowdStrike Falcon | Set CID received from API
+  ansible.builtin.set_fact:
+    falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -7,6 +7,13 @@
     - falcon_remove_aid
 
 - block:
+    - ansible.builtin.include_tasks: api.yml
+      # noqa unnamed-task 502
+  when:
+    - falcon_client_id and falcon_client_secret
+    - not falcon_cid
+
+- block:
     - ansible.builtin.include_tasks: configure.yml
       # noqa unnamed-task 502
   when:

--- a/roles/falcon_configure/vars/main.yml
+++ b/roles/falcon_configure/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for falcon_configure
+falcon_cloud: "api.crowdstrike.com"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,10 @@
 ---
 - hosts: localhost
   remote_user: root
+  vars:
+    falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+    falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
   roles:
-    - crowdstrike.falcon.falcon_install
-    - crowdstrike.falcon.falcon_uninstall
+    - role: crowdstrike.falcon.falcon_install
+    - role: crowdstrike.falcon.falcon_configure
+    - role: crowdstrike.falcon.falcon_uninstall


### PR DESCRIPTION
closes #113 

- Adds the ability to autodetect CID if API credentials are known. This is something that was originally in falcon_installation.
- Added tests in Molecule
- Updated our collections tests to showcase usage and make it actually workable