### PR TITLE
Add duplicate API task to authenticate to cloud

### DIFF
--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -7,6 +7,7 @@
     body:
       "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
     return_content: true
+    follow_redirects: all
     status_code: 201
     headers:
       content-type: application/x-www-form-urlencoded

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -1,21 +1,35 @@
 ---
-- name: CrowdStrike Falcon | Authenticate to CrowdStrike API
+- name: CrowdStrike Falcon | Authenticate to CrowdStrike Cloud to Auto-discover Region
   ansible.windows.win_uri:
     url: "https://{{ falcon_cloud }}/oauth2/token"
     method: POST
-    body: "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
+    body:
+      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
     return_content: true
-    status_code: 201
+    status_code: 201,308
     headers:
-      content-type: application/x-www-form-urlencoded
+      content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
 
-- name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
+- name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
   ansible.builtin.set_fact:
       falcon_cloud: "{{ falcon_cloud_urls[falcon_api_oauth2_token.x_cs_region] }}"
   when:
     - falcon_cloud_autodiscover
     - falcon_api_oauth2_token.x_cs_region|length > 0
+
+- name: CrowdStrike Falcon | Authenticate to CrowdStrike API with Auto-discovered Region
+  ansible.windows.win_uri:
+    url: "https://{{ falcon_cloud }}/oauth2/token"
+    method: POST
+    body: "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
+    return_content: true
+    status_code: 200,201
+    headers:
+      content-type: "application/x-www-form-urlencoded; charset=utf-8"
+  register: falcon_api_oauth2_token
+  when:
+    - falcon_cloud_autodiscover
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.windows.win_uri:


### PR DESCRIPTION
- Redirects are no longer working and the payload is never returned with the oauth token. This is a janky fix that 
   authenticates to the API twice to get the token and csregion in separate tasks