### PR TITLE
added continue-on-error to molecule run

### DIFF
--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -60,6 +60,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
+        continue-on-error: true
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -60,6 +60,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
+        continue-on-error: true
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -60,6 +60,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
+        continue-on-error: true
         run: >-
           molecule --version &&
           ansible --version &&


### PR DESCRIPTION
This allows us to still test Windows, but not be concerned with the current flakiness surrounding the molecule testing on Windows.