### PR TITLE
Added issue with handler not running with sudo

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.4
+version: 3.2.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_configure/handlers/main.yml
+++ b/roles/falcon_configure/handlers/main.yml
@@ -6,3 +6,4 @@
       state: "{{ falcon_service_state | default('restarted') }}"
       enabled: yes
     when: info.falconctl_info.cid
+    become: yes


### PR DESCRIPTION
Fixed an issue where the restart sensor task was failing because it wasn't assuming elevated privileges. We didn't catch this in molecule since the containers use root by default.