### PR TITLE
Fixes issue with EOL Centos8 mirrors

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         molecule_distro:
           - { "distro":"centos7" }
-          - { "distro":"centos8" }
+          - { "distro":"rockylinux8" }
           - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
           - { "distro":"debian10" }

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         molecule_distro:
           - { "distro":"centos7" }
-          - { "distro":"centos8" }
+          - { "distro":"rockylinux8" }
           - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
           - { "distro":"debian10" }

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         molecule_distro:
           - { "distro":"centos7" }
-          - { "distro":"centos8" }
+          - { "distro":"rockylinux8" }
           - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
           - { "distro":"debian10" }


### PR DESCRIPTION
There is an issue with CentOS8 finally getting EOL'd. This replaces centos8 with rockylinux8. I've submitted an upstream [PR](https://github.com/geerlingguy/docker-centos8-ansible/issues/19) to fix the current issue which is to point to the new vaulted mirrors for packages, but this is an archive, and will not be updated. 

I've also submitted an [issue](https://github.com/geerlingguy/docker-centos8-ansible/issues/20) to see if he can create a new repo for CentOS Stream, as this is the way forward. 