### PR TITLE
Added no_log to API tasks to prevent sensitive output

### DIFF
--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -11,6 +11,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
+  no_log: yes
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.builtin.uri:
@@ -21,6 +22,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
+  no_log: yes
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -12,6 +12,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
+  no_log: yes
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -39,6 +40,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
+    no_log: yes
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -82,6 +84,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
+  no_log: yes
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.builtin.get_url:
@@ -92,6 +95,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
+  no_log: yes
 
 - name: CrowdStrike Falcon | Set full file download path
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -10,6 +10,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
+  no_log: yes
 
 - name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -28,6 +29,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
+  no_log: yes
   when:
     - falcon_cloud_autodiscover
 
@@ -40,6 +42,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
+  no_log: yes
 
 # Block when falcon_sensor_update_policy_name is supplied
 - block:
@@ -60,6 +63,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
+    no_log: yes
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -90,6 +94,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
+  no_log: yes
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.windows.win_get_url:
@@ -101,6 +106,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
+  no_log: yes
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:


### PR DESCRIPTION
Fixes #146 

This implements Ansible's no_log feature to essentially hide any output that could be logged to expose api creds. As the OP of #146 stated, there is an open issue for the uri module to add a header_secret, but until then, this is the only way to mask it.