### PR TITLE
Added new api feature + variablized no_log option

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -62,4 +62,4 @@ jobs:
           molecule --version &&
           ansible --version &&
           MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v
+          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -61,4 +61,4 @@ jobs:
           molecule --version &&
           ansible --version &&
           MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v
+          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -61,4 +61,4 @@ jobs:
           molecule --version &&
           ansible --version &&
           MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v
+          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -11,7 +11,7 @@ Ansible 2.11 or higher
 Role Variables
 --------------
 
- * `falcon_api_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
+ * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
  * `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
  * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
  * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -11,6 +11,7 @@ Ansible 2.11 or higher
 Role Variables
 --------------
 
+ * `falcon_api_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
  * `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
  * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
  * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -2,15 +2,14 @@
 # defaults file for falcon_configure
 
 # Whether to enable or disable the logging of sensitive data being exposed in API calls.
-# The default is `yes`.
+# By default, this is enabled.
 #
-# Setting this to `no` can expose your falcon_client_secret and bearer token when
-# verbosity is turned up.
+# Disabling this can expose your API credentials and authorization token.
 #
-falcon_api_no_log: yes
+falcon_api_enable_no_log: yes
 
 # Controls whether you would like to set or delete options associated with the Falcon Sensor.
-# The default is `yes` to set options.
+# The default is `yes` - to SET options.
 falcon_option_set: yes
 
 # Your Falcon Customer ID (CID) used to associate your sensor.

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -1,5 +1,16 @@
 ---
 # defaults file for falcon_configure
+
+# Whether to enable or disable the logging of sensitive data being exposed in API calls.
+# The default is `yes`.
+#
+# Setting this to `no` can expose your falcon_client_secret and bearer token when
+# verbosity is turned up.
+#
+falcon_api_no_log: yes
+
+# Controls whether you would like to set or delete options associated with the Falcon Sensor.
+# The default is `yes` to set options.
 falcon_option_set: yes
 
 # Your Falcon Customer ID (CID) used to associate your sensor.

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -11,7 +11,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.builtin.uri:
@@ -22,7 +22,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -11,7 +11,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.builtin.uri:
@@ -22,7 +22,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -13,7 +13,8 @@ Role Variables
 
 The following variables are currently supported:
 
- * `falcon_api_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
+ * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
+ * `falcon_skip_kernel_compat_check` - Whether or not to ignore errors associated with unsupported Falcon Sensor/Kernel combination. (bool, default: false)
  * `falcon_install_method` - The installation method for installing the sensor (string, default: api)
  * `falcon_gpg_key` - Location of the Falcon GPG Key file (string, default: null)
  * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `api.crowdstrike.com`)

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -13,6 +13,7 @@ Role Variables
 
 The following variables are currently supported:
 
+ * `falcon_api_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
  * `falcon_install_method` - The installation method for installing the sensor (string, default: api)
  * `falcon_gpg_key` - Location of the Falcon GPG Key file (string, default: null)
  * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `api.crowdstrike.com`)

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -2,12 +2,19 @@
 # defaults file for falcon_install
 
 # Whether to enable or disable the logging of sensitive data being exposed in API calls.
-# The default is yes|true.
+# By default, this is enabled.
 #
-# Setting this to no|false can expose your falcon_client_secret and bearer token when
-# verbosity is turned up.
+# Disabling this can expose your API credentials and authorization token.
 #
-falcon_api_no_log: yes
+falcon_api_enable_no_log: yes
+
+# Whether or not to ignore errors associated with unsupported Falcon Sensor Kernel
+# configurations.
+#
+# By default, this is disabled - which will fail the play when the Falcon Sensor and Kernel
+# are unsupported.
+#
+falcon_skip_kernel_compat_check: no
 
 # This installer is capable of three different installation
 # methods:

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -1,6 +1,14 @@
 ---
 # defaults file for falcon_install
 
+# Whether to enable or disable the logging of sensitive data being exposed in API calls.
+# The default is yes|true.
+#
+# Setting this to no|false can expose your falcon_client_secret and bearer token when
+# verbosity is turned up.
+#
+falcon_api_no_log: yes
+
 # This installer is capable of three different installation
 # methods:
 #

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -12,7 +12,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -40,7 +40,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
-    no_log: "{{ falcon_api_no_log }}"
+    no_log: "{{ falcon_api_enable_no_log }}"
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -84,7 +84,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 # Block for checking sensor/kernel compatibility
 - block:
@@ -101,13 +101,13 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_kernels_list
-    no_log: "{{ falcon_api_no_log }}"
+    no_log: "{{ falcon_api_enable_no_log }}"
 
   - name: CrowdStrike Falcon | Validate Kernel is Supported
     ansible.builtin.assert:
       that: falcon_sensor_update_kernels_list.json.resources
-      fail_msg: "It appears this kernel version: {{ ansible_kernel }} is not supported!"
-    ignore_errors: yes
+      fail_msg: "The kernel version: {{ ansible_kernel }} is not supported by the Falcon Sensor!"
+    ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
 
   - name: CrowdStrike Falcon | Validate Sensor version is compatible with Kernel
     ansible.builtin.assert:
@@ -117,7 +117,7 @@
       falcon_sensor_version: "{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].version }}"
       falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].base_package_supported_sensor_versions }}"
     when: falcon_sensor_update_kernels_list.json.resources
-    ignore_errors: yes
+    ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
   when: ansible_system == "Linux"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
@@ -129,7 +129,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Set full file download path
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -12,7 +12,7 @@
     headers:
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -40,7 +40,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
-    no_log: yes
+    no_log: "{{ falcon_api_no_log }}"
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -84,7 +84,41 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
+
+# Block for checking sensor/kernel compatibility
+- block:
+  - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
+    ansible.builtin.set_fact:
+      falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+distro_version:\"' + ansible_distribution_version + '\"+release:\"' + ansible_kernel + '\"' }}"
+
+  - name: CrowdStrike Falcon | Get list of Supported Kernels
+    ansible.builtin.uri:
+      url: "https://{{ falcon_cloud }}/policy/combined/sensor-update-kernels/v1?filter={{ falcon_sensor_update_kernels_query | urlencode }}"
+      method: GET
+      return_content: true
+      headers:
+        authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+        Content-Type: application/json
+    register: falcon_sensor_update_kernels_list
+    no_log: "{{ falcon_api_no_log }}"
+
+  - name: CrowdStrike Falcon | Validate Kernel is Supported
+    ansible.builtin.assert:
+      that: falcon_sensor_update_kernels_list.json.resources
+      fail_msg: "It appears this kernel version: {{ ansible_kernel }} is not supported!"
+    ignore_errors: yes
+
+  - name: CrowdStrike Falcon | Validate Sensor version is compatible with Kernel
+    ansible.builtin.assert:
+      that: falcon_sensor_version in falcon_base_package_supported_sensor_versions
+      fail_msg: "The sensor version: {{ falcon_sensor_version }} is not supported with kernel: {{ ansible_kernel }}"
+    vars:
+      falcon_sensor_version: "{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].version }}"
+      falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].base_package_supported_sensor_versions }}"
+    when: falcon_sensor_update_kernels_list.json.resources
+    ignore_errors: yes
+  when: ansible_system == "Linux"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.builtin.get_url:
@@ -95,7 +129,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Set full file download path
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -33,6 +33,7 @@
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
     falcon_sensor_update_policy_platform: "{{ ansible_system }}"
+    falcon_os_vendor: "{{ ansible_os_family|lower if (ansible_os_family == 'RedHat') else ansible_distribution|lower }}"
 
 - name: "CrowdStrike Falcon | Determine if Endpoint Operating System Is RHEL, CentOS, or Oracle Linux"
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -10,7 +10,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -29,7 +29,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
   when:
     - falcon_cloud_autodiscover
 
@@ -42,7 +42,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 # Block when falcon_sensor_update_policy_name is supplied
 - block:
@@ -63,7 +63,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
-    no_log: "{{ falcon_api_no_log }}"
+    no_log: "{{ falcon_api_enable_no_log }}"
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -94,7 +94,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.windows.win_get_url:
@@ -106,7 +106,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
-  no_log: "{{ falcon_api_no_log }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -10,7 +10,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -29,7 +29,7 @@
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
   when:
     - falcon_cloud_autodiscover
 
@@ -42,7 +42,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_target_cid
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 # Block when falcon_sensor_update_policy_name is supplied
 - block:
@@ -63,7 +63,7 @@
         authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
         Content-Type: application/json
     register: falcon_sensor_update_policy_info
-    no_log: yes
+    no_log: "{{ falcon_api_no_log }}"
 
   - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
     ansible.builtin.fail:
@@ -94,7 +94,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
       Content-Type: application/json
   register: falcon_api_installer_list
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.windows.win_get_url:
@@ -106,7 +106,7 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
-  no_log: yes
+  no_log: "{{ falcon_api_no_log }}"
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:


### PR DESCRIPTION
Closes #148

- Adds new sensor-update-kernels API functionality. This gives us the ability to check if the kernel on Linux is compatible, and if so, is the sensor-version being used compatible with the kernel.
  - Currently this will issue a failure warning, but will be ignored. This can be useful to see if the deployment will most likely result in the falcon sensor being in RFM mode due to kernel compatibility issues.
- Added a new variable: `falcon_api_enable_no_log` to manage whether or not a user might want to expose their API credentials + authorization token during a run. It may be useful for troubleshooting purposes, otherwise we think it's a good idea to leave this at the default value.
- Added a new variable: `falcon_skip_kernel_compat_check` to manage whether or not a user would like to ignore errors associated with unsupported falcon sensor/kernel combination.