### PR TITLE
Slimming down OS's for CI

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -31,9 +31,7 @@ jobs:
         molecule_distro:
           - { "distro":"centos7" }
           - { "distro":"rockylinux8" }
-          - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
-          - { "distro":"debian10" }
         collection_role:
           - falcon_configure
     steps:

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -30,9 +30,7 @@ jobs:
         molecule_distro:
           - { "distro":"centos7" }
           - { "distro":"rockylinux8" }
-          - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
-          - { "distro":"debian10" }
         collection_role:
           - falcon_install
     steps:

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -30,9 +30,7 @@ jobs:
         molecule_distro:
           - { "distro":"centos7" }
           - { "distro":"rockylinux8" }
-          - { "distro":"amazonlinux2" }
           - { "distro":"ubuntu2004" }
-          - { "distro":"debian10" }
         collection_role:
           - falcon_uninstall
     steps:

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         molecule_distro:
-          - { "distro":"WindowsServer2012R2" }
-          - { "distro":"WindowsServer2016" }
+          # - { "distro":"WindowsServer2012R2" }
+          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_configure

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         molecule_distro:
-          - { "distro":"WindowsServer2012R2" }
-          - { "distro":"WindowsServer2016" }
+          # - { "distro":"WindowsServer2012R2" }
+          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_install

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         molecule_distro:
-          - { "distro":"WindowsServer2012R2" }
-          - { "distro":"WindowsServer2016" }
+          # - { "distro":"WindowsServer2012R2" }
+          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_uninstall


### PR DESCRIPTION
Slim down the number of OS to run for our CI molecule testing. A lot of them are redundant and provide no additional insight.