### PR TITLE
Due to limitation in api, removed distro_version filter

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,6 +6,7 @@ enable_list:
 
 skip_list:
   - '204'
+  - 'ignore-errors'
 
 warn_list:
   - experimental

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.6
+version: 3.2.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -90,7 +90,7 @@
 - block:
   - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
     ansible.builtin.set_fact:
-      falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+distro_version:\"' + ansible_distribution_version + '\"+release:\"' + ansible_kernel + '\"' }}"
+      falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_kernel + '\"' }}"
 
   - name: CrowdStrike Falcon | Get list of Supported Kernels
     ansible.builtin.uri:


### PR DESCRIPTION
on RHEL - there was an issue with distro_version not being correct according to the kernel version. This now filters based on vendor and kernel version to get supported sensors.