### PR TITLE
Fixed typo in configure task, plus bool issue for cid

### DIFF
--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -13,7 +13,7 @@
       message_log: "{{ falcon_message_log if (falcon_message_log != None) else omit }}"
       billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
       tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
-      state: "{{ 'present' if falcon_option_set else 'absent' }}"
+      state: "{{ 'present' if falcon_option_state else 'absent' }}"
     notify: CrowdStrike Falcon | Restart Falcon Sensor
 
   - name: CrowdStrike Falcon | Register Falcon Sensor Options

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -11,7 +11,7 @@
       # noqa unnamed-task 502
   when:
     - falcon_client_id and falcon_client_secret
-    - not falcon_cid
+    - not falcon_cid|length == 0
 
 - block:
     - ansible.builtin.include_tasks: configure.yml


### PR DESCRIPTION
Fixes #158 

- Fixed typo that prevented the appropriate state
- Fixed issue when passing `falcon_cid: ""` which would force the api.yml tasks to run