### PR TITLE
Fixed typo in falcon_configure README + api task issue

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.7
+version: 3.2.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -120,7 +120,7 @@ Examples of deleting options:
   roles:
   - role: crowdstrike.falcon.falcon_configure
     vars:
-      falcon_option_state: no
+      falcon_option_set: no
       falcon_cid: ""
       falcon_tags: ""
 ```
@@ -131,7 +131,7 @@ Delete Agent ID to prep Master Image:
   roles:
   - role: crowdstrike.falcon.falcon_configure
     vars:
-      falcon_option_state: no
+      falcon_option_set: no
       falcon_remove_aid: yes
 ```
 

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -11,6 +11,7 @@
       # noqa unnamed-task 502
   when:
     - falcon_client_id and falcon_client_secret
+    - falcon_option_set
     - not falcon_cid
 
 - block:


### PR DESCRIPTION
Fixes #158 

- Fix mistake in the `falcon_configure` role README wrt deleting falcon options
- Fix bool logic in when clause that caused CID option not to be deleted properly
- Bump version