### PR TITLE
Ignore .devcontainer from collection build

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y libyaml-dev python3-venv
+          sudo apt-get install -y libyaml-dev
           python -m pip install --upgrade pip
           pip install ansible yamllint jinja2 pylint pyyaml voluptuous
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -69,4 +69,5 @@ issues: https://github.com/CrowdStrike/ansible_collection_crowdstrike/issues
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered
-build_ignore: []
+build_ignore:
+  - '.devcontainer'


### PR DESCRIPTION
- Removes .devcontainer from being included in the ansible-collection build, which prevents shellcheck issues associated with files in there
- Updates ansible-test workflow to support new python 3.10.4 version.