### PR TITLE
Adding purge for apt-based uninstalls

### DIFF
--- a/roles/falcon_uninstall/tasks/uninstall.yml
+++ b/roles/falcon_uninstall/tasks/uninstall.yml
@@ -9,6 +9,7 @@
   ansible.builtin.package:
     name: falcon-sensor
     state: absent
+    purge: "{{ True if (ansible_pkg_mgr == 'apt') else omit }}"
   when:
     - ansible_system == "Linux"
 


### PR DESCRIPTION
There was an issue when running the uninstall_role would not completely purge the falcon-sensor package from debian based systems.