### PR TITLE
re-added ansible galaxy upload command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Create release artifacts
         run: |
           ansible-galaxy collection build
+          ansible-galaxy collection publish *.tar.gz --api-key ${{ secrets.GALAXY_API_KEY }}
       - name: Release artifacts to GitHub
         run: |
           gh release upload $TAG ./crowdstrike-falcon*.tar.gz


### PR DESCRIPTION
This was removed in #162 

@redhatrises I believe this was accidental and was not the cause for the failing of the GH release upload right?