### PR TITLE
Updated when clause to ensure task only on legacy amzn os

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.10
+version: 3.2.11
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -25,7 +25,9 @@
 - name: "CrowdStrike Falcon | Configure Python Interpreter for older Linux OSes"
   ansible.builtin.set_fact:
     ansible_python_interpreter: /usr/bin/python
-  when: ansible_distribution == "Amazon"
+  when:
+    - ansible_distribution == "Amazon"
+    - ansible_distribution_major_version | int < 2
 
 - name: "CrowdStrike Falcon | Default Operating System configuration"
   ansible.builtin.set_fact:


### PR DESCRIPTION
fixes #172 

- Bump'd version
- Fixed when clause to only target legacy amzn1 os