### PR TITLE
Fix amazon os family error

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.13
+version: 3.2.14
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -35,7 +35,7 @@
     falcon_os_family: "{{ ansible_system | lower }}"
     falcon_os_version: "{{ ansible_distribution_major_version }}"
     falcon_sensor_update_policy_platform: "{{ ansible_system }}"
-    falcon_os_vendor: "{{ ansible_os_family|lower if (ansible_os_family == 'RedHat') else ansible_distribution|lower }}"
+    falcon_os_vendor: "{{ ansible_os_family|lower if (ansible_os_family == 'RedHat' and ansible_distribution != 'Amazon') else ansible_distribution|lower }}"
 
 - name: "CrowdStrike Falcon | Determine if Endpoint Operating System Is RHEL, CentOS, or Oracle Linux"
   ansible.builtin.set_fact:


### PR DESCRIPTION
This fixes an issue with Amazon Linux reporting the wrong falcon_os_vendor value since it's os_family is RedHat.