### PR TITLE
Molecule seems to no longer install ansible according to pip

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] yamllint ansible-lint==5.4.0
+          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint==5.4.0
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] yamllint ansible-lint==5.4.0
+          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint==5.4.0
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] yamllint ansible-lint==5.4.0
+          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint==5.4.0
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install molecule[vagrant,lint,ansible] yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
+          pip install molecule[vagrant,lint,ansible] ansible yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install molecule[vagrant,lint,ansible] yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
+          pip install molecule[vagrant,lint,ansible] ansible yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install molecule[vagrant,lint,ansible] yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
+          pip install molecule[vagrant,lint,ansible] ansible yamllint ansible-lint==5.4.0 python-vagrant molecule-vagrant "pywinrm>=0.3.0"
 
       - name: Build/Install the collection
         run: |


### PR DESCRIPTION
During pip install - this is the message received as to why Ansible does not get installed:
```shell
WARNING: molecule 4.0.0 does not provide the extra 'ansible'
```

This PR add ansible to pip list