### PR TITLE
Fixed issue with duplicate api-call overwriting registerd var

### DIFF
--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -19,20 +19,6 @@
     - falcon_cloud_autodiscover
     - falcon_api_oauth2_token.x_cs_region|length > 0
 
-- name: CrowdStrike Falcon | Authenticate to CrowdStrike API with Auto-discovered Region
-  ansible.windows.win_uri:
-    url: "https://{{ falcon_cloud }}/oauth2/token"
-    method: POST
-    body: "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
-    return_content: true
-    status_code: 200,201
-    headers:
-      content-type: "application/x-www-form-urlencoded; charset=utf-8"
-  register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_enable_no_log }}"
-  when:
-    - falcon_cloud_autodiscover
-
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.windows.win_uri:
     url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1


### PR DESCRIPTION
Fixes #201 

The duplicate api call to authenticate task was causing the already registered `falcon_api_oauth2_token` variable to be wiped when skipped over. This fix makes it inline with how we do it on the *nix side.