### PR TITLE
Redirects should have been added to other role/tasks

### DIFF
--- a/molecule/falcon_configure/converge.yml
+++ b/molecule/falcon_configure/converge.yml
@@ -1,6 +1,9 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+    falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
   roles:
     - role: crowdstrike.falcon.falcon_configure
       vars:

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -7,6 +7,7 @@
     body:
       "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
     return_content: true
+    follow_redirects: all
     status_code: 201
     headers:
       content-type: application/x-www-form-urlencoded

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -6,7 +6,8 @@
     body:
       "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
     return_content: true
-    status_code: 201,308
+    follow_redirects: all
+    status_code: 201
     headers:
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token


### PR DESCRIPTION
closes #217 

* Fixes missing redirect follows in falcon_configure role and win_api.yml task in falcon_install role
* Updates molecule falcon_configure testing to ensure this is easier to test locally