### PR TITLE
Pages WF needs permission to push to branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR introduces the permissions needed to push content to the gh-pages branch via the workflow