### PR TITLE
Adding retries to reflect better test status

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -65,8 +65,13 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        run: >-
-          molecule --version &&
-          ansible --version &&
-          MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 6
+          max_attempts: 3
+          retry-on: error
+          command: >-
+            molecule --version &&
+            ansible --version &&
+            MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
+            molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"

--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           timeout_minutes: 6
           max_attempts: 3
-          retry-on: error
+          retry_on: error
           command: >-
             molecule --version &&
             ansible --version &&

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           timeout_minutes: 6
           max_attempts: 3
-          retry-on: error
+          retry_on: error
           command: >-
             molecule --version &&
             ansible --version &&

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -64,8 +64,13 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        run: >-
-          molecule --version &&
-          ansible --version &&
-          MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 6
+          max_attempts: 3
+          retry-on: error
+          command: >-
+            molecule --version &&
+            ansible --version &&
+            MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
+            molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           timeout_minutes: 6
           max_attempts: 3
-          retry-on: error
+          retry_on: error
           command: >-
             molecule --version &&
             ansible --version &&

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -64,8 +64,13 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        run: >-
-          molecule --version &&
-          ansible --version &&
-          MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
-          molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 6
+          max_attempts: 3
+          retry-on: error
+          command: >-
+            molecule --version &&
+            ansible --version &&
+            MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
+            molecule --debug test -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"


### PR DESCRIPTION
Allow a way to retry molecule failed jobs - that are usually caused by some race condition or some quirk. Manually re-running a failed job usually fixes the issue, so this is an attempt to do it programatically.