### PR TITLE
Fix incorrect arm64 assumptions on api call

### DIFF
--- a/changelogs/fragments/fix-incorrect-arm64-assumptions.yml
+++ b/changelogs/fragments/fix-incorrect-arm64-assumptions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_install - fix-incorrect-arm64-assumptions (https://github.com/CrowdStrike/ansible_collection_falcon/issues/244)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -69,8 +69,8 @@
 
 - name: "CrowdStrike Falcon | Build API Sensor Query"
   ansible.builtin.set_fact:
-    falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_version + '\"'
-      if (falcon_sensor_version) else 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"' }}"
+    falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + falcon_os_arch + '+version:\"' + falcon_sensor_version + '\"'
+      if (falcon_sensor_version) else 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + falcon_os_arch }}"
   when: not falcon_sensor_update_policy_name
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -33,9 +33,10 @@
   ansible.builtin.set_fact:
     falcon_target_os: "{{ ansible_distribution }}"
     falcon_os_family: "{{ ansible_system | lower }}"
-    falcon_os_version: "{{ ansible_distribution_major_version }}"
+    falcon_os_version: "*{{ ansible_distribution_major_version }}*"
     falcon_sensor_update_policy_platform: "{{ ansible_system }}"
     falcon_os_vendor: "{{ ansible_os_family | lower if (ansible_os_family == 'RedHat' and ansible_distribution != 'Amazon') else ansible_distribution | lower }}"
+    falcon_os_arch: "{{ '\"+os_version:!~\"arm64\"' if ansible_architecture == 'x86_64' else '\"+os_version:~\"arm64\"' }}"
 
 - name: "CrowdStrike Falcon | Determine if Endpoint Operating System Is RHEL, CentOS, or Oracle Linux"
   ansible.builtin.set_fact:
@@ -46,23 +47,6 @@
   ansible.builtin.set_fact:
     falcon_target_os: "Amazon Linux"
   when: ansible_distribution == "Amazon"
-
-- name: "CrowdStrike Falcon | Determine if Target OS Is Amazon Linux ARM architecture"
-  ansible.builtin.set_fact:
-    falcon_os_version: "2 - arm64"
-  when: ansible_distribution == "Amazon" and ansible_machine == "aarch64"
-
-- name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Debian"
-  ansible.builtin.set_fact:
-    falcon_os_version: "*{{ falcon_os_version }}*"
-  when:
-    - ansible_distribution == "Debian"
-
-- name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Ubuntu"
-  ansible.builtin.set_fact:
-    falcon_os_version: "*{{ falcon_os_version }}*"
-  when:
-    - ansible_distribution == "Ubuntu"
 
 - name: CrowdStrike Falcon | Determine if Target OS Is MacOS
   ansible.builtin.set_fact:


### PR DESCRIPTION
fixes #244 
This fixes an error with our API not having an existing architecture field to ensure that when we ask for the list of available sensors to download, we get the one for the existing architecture.