### PR TITLE
add python linting to pre_commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
 	"name": "Ansible DinD",
 	"dockerFile": "Dockerfile",
-	"runArgs": ["--init", "--privileged"],
+	"runArgs": [
+		"--init",
+		"--privileged"
+	],
 	"mounts": [
 		// [Optional] Anisble Collections: Uncomment if you want to mount your local .ansible/collections folder.
 		"source=${localWorkspaceFolder},target=/usr/share/ansible/collections/ansible_collections/crowdstrike/falcon,type=bind,consistency=cached",
@@ -9,7 +12,6 @@
 		"source=dind-var-lib-docker,target=/var/lib/docker,type=volume"
 	],
 	"overrideCommand": false,
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"files.associations": {
@@ -34,23 +36,19 @@
 		"[python]": {
 			"editor.tabSize": 4
 		}
-	  },
-
+	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"redhat.ansible",
 		"shd101wyy.markdown-preview-enhanced",
 		"ms-python.python",
 		"redhat.vscode-yaml",
-		"ms-azuretools.vscode-docker"
+		"ms-azuretools.vscode-docker",
+		"redhat.ansible"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pre-commit install",
-
+	"postCreateCommand": "pre-commit install --install-hooks",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -7,3 +7,4 @@ molecule-vagrant
 flake8
 pylint
 pre-commit
+autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,13 @@ repos:
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/PyCQA/pylint
+    rev: v2.15.0
+    hooks:
+      - id: pylint


### PR DESCRIPTION
* Add flake8 and pylint to pre_commit
* Update pre_commit install to also initialize the hook environments
* Moved ansible extension down the list since it depends on the python extension
* Add autopep8

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/35144141/187992354-df6abc02-5f24-434e-9015-ae0af1ca260f.png">
