### PR TITLE
Fixed issue with removing aid for master image prep in falcon_configure

### DIFF
--- a/changelogs/fragments/fix-failing-aid-master-prep.yml
+++ b/changelogs/fragments/fix-failing-aid-master-prep.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_configure - fix issue with aid removal for image prep failed (https://github.com/CrowdStrike/ansible_collection_falcon/issues/254)

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -45,13 +45,19 @@
       name: crowdstrike.falcon.falcon_configure
     vars:
       falcon_option_set: no
-      falcon_remove_aid: yes
       falcon_cid: ""
       falcon_tags: ""
       falcon_billing: ""
       falcon_apd: ""
       falcon_aph: ""
       falcon_app: ""
+
+  - name: Test Deleting AID master image prep
+    ansible.builtin.include_role:
+      name: crowdstrike.falcon.falcon_configure
+    vars:
+      falcon_option_set: no
+      falcon_remove_aid: yes
 
   - name: Get Updated Falcon Sensor Option
     crowdstrike.falcon.falconctl_info:

--- a/roles/falcon_configure/handlers/main.yml
+++ b/roles/falcon_configure/handlers/main.yml
@@ -1,9 +1,2 @@
 ---
 # handlers file for falcon_configure
-  - name: CrowdStrike Falcon | Restart Falcon Sensor
-    ansible.builtin.service:
-      name: falcon-sensor
-      state: "{{ falcon_service_state | default('restarted') }}"
-      enabled: yes
-    when: info.falconctl_info.cid
-    become: yes

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -14,17 +14,21 @@
         billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
         tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
         state: "{{ 'present' if falcon_option_set else 'absent' }}"
-      notify: CrowdStrike Falcon | Restart Falcon Sensor
+      register: falconctl_result
 
     - name: CrowdStrike Falcon | Register Falcon Sensor Options
       crowdstrike.falcon.falconctl_info:
       register: info
 
-    - name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
-      crowdstrike.falcon.falconctl:
-        aid: yes
-        state: absent
-      when: falcon_remove_aid
+    - name: CrowdStrike Falcon | Restart Falcon Sensor on Changes
+      ansible.builtin.service:
+        name: falcon-sensor
+        state: "{{ falcon_service_state | default('restarted') }}"
+        enabled: yes
+      when:
+        - info.falconctl_info.cid
+        - falconctl_result.changed
+      become: yes
 
   when: ansible_distribution != "MacOSX"
 

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -1,11 +1,5 @@
 ---
 # tasks file for falcon_configure
-- name: CrowdStrike Falcon | Set service state for Primary Images
-  ansible.builtin.set_fact:
-    falcon_service_state: stopped
-  when:
-    - falcon_remove_aid
-
 - block:
     - ansible.builtin.include_tasks: api.yml
       # noqa unnamed-task 502
@@ -19,8 +13,14 @@
       # noqa unnamed-task 502
   when:
     - ansible_os_family != "Windows"
+    - not falcon_remove_aid
   become: true
   become_user: root
+
+- block:
+    - ansible.builtin.include_tasks: remove_aid.yml
+      # noqa unnamed-task 502
+  when: falcon_remove_aid
 
 - block:
     - ansible.builtin.include_tasks: win_configure.yml

--- a/roles/falcon_configure/tasks/remove_aid.yml
+++ b/roles/falcon_configure/tasks/remove_aid.yml
@@ -1,0 +1,5 @@
+---
+- name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
+  crowdstrike.falcon.falconctl:
+    aid: yes
+    state: absent


### PR DESCRIPTION
closes #254 

When trying to remove the aid to prep for master image/clone, there was an issue with embedding the `falcon_remove_aid` functionality into the configure task. This was causing this task to always run:
```yaml
- name: CrowdStrike Falcon | Configure Falcon Sensor Options (Linux)
```
By extracting the actual tasks needed to remove the aid - and prevent the service from being bounced, a few changes were introduced to this PR:
- No longer need a handler for this role. The sensor should be bounced immediately after registering changes. This allows users to run a play where they add the CID and other config items, then want to remove the aid to prep an image. Example playbook:
```yaml
---
- name: Configure and prep falcon
  hosts: all
  tasks:
    - name: Set CID and tags
      ansible.builtin.include_role:
        name: crowdstrike.falcon.falcon_configure
      vars:
        falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
        falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
        falcon_tags: 'testing123'

    - name: Delete Agent ID to prep Master Image
      ansible.builtin.include_role:
        name: crowdstrike.falcon.falcon_configure
      vars:
        falcon_option_set: no
        falcon_remove_aid: yes
```
- Updated main.yml to include new `remove_aid.yml` task
- Updated molecule testing to reflect new changes
- Added changelog fragment