### PR TITLE
Fix falcon_cloud in falcon_configure role functionality

### DIFF
--- a/changelogs/fragments/fix-falcon-configure-var-issue.yaml
+++ b/changelogs/fragments/fix-falcon-configure-var-issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_configure - fix issue with falcon_cloud variable not being set correctly (https://github.com/CrowdStrike/ansible_collection_falcon/issues/257)

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -13,6 +13,8 @@ Role Variables
 
  * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
  * `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
+ * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `api.crowdstrike.com`)
+ * `falcon_cloud_autodiscover` - Auto-discover CrowdStrike API Cloud region (bool, default: true)
  * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
  * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)
  * `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: null)

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -12,6 +12,19 @@ falcon_api_enable_no_log: yes
 # The default is `yes` - to SET options.
 falcon_option_set: yes
 
+# CrowdStrike API URL for downloading the Falcon sensor. Possible values:
+#       us-1:       api.crowdstrike.com
+#       us-2:       api.us-2.crowdstrike.com
+#       eu-1:       api.eu-1.crowdstrike.com
+#       us-gov-1:   api.laggar.gcw.crowdstrike.com
+#
+falcon_cloud: "api.crowdstrike.com"
+
+# Auto-discover the CrowdStrike Cloud API Region. When disabled,
+# 'falcon_cloud' should be changed to the appropriate cloud region.
+#
+falcon_cloud_autodiscover: true
+
 # Your Falcon Customer ID (CID) used to associate your sensor.
 #
 falcon_cid:

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -14,6 +14,13 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
 
+- name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
+  ansible.builtin.set_fact:
+      falcon_cloud: "{{ falcon_cloud_urls[falcon_api_oauth2_token.x_cs_region] }}"
+  when:
+    - falcon_cloud_autodiscover
+    - falcon_api_oauth2_token.x_cs_region | length > 0
+
 - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
   ansible.builtin.uri:
     url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1

--- a/roles/falcon_configure/vars/main.yml
+++ b/roles/falcon_configure/vars/main.yml
@@ -1,3 +1,7 @@
 ---
 # vars file for falcon_configure
-falcon_cloud: "api.crowdstrike.com"
+falcon_cloud_urls:
+  us-1: "api.crowdstrike.com"
+  us-2: "api.us-2.crowdstrike.com"
+  eu-1: "api.eu-1.crowdstrike.com"
+  us-gov-1: "api.laggar.gcw.crowdstrike.com"


### PR DESCRIPTION
closes #257 

This issue stemmed from the `falcon_cloud` variable in the `falcon_configure` role being technically in the wrong place. However, this PR fixes that issue, as well as brings the API authentication functionality in the `falcon_install` role in line with this role.