### PR TITLE
Implement run once feature

### DIFF
--- a/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -82,7 +82,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}
+    local last_part_optional=${5:-"false"}    
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part

--- a/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -82,7 +82,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -13,6 +13,7 @@
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: yes
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:

--- a/roles/falcon_configure/tasks/api.yml
+++ b/roles/falcon_configure/tasks/api.yml
@@ -32,6 +32,7 @@
       Content-Type: application/json
   register: falcon_api_target_cid
   no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: yes
 
 - name: CrowdStrike Falcon | Set CID received from API
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -23,8 +23,10 @@
     - falcon_api_oauth2_token.x_cs_region | length > 0
 
 # Block when falcon_sensor_update_policy_name is supplied
-- name: Sensor Update Policy Block
-  when: falcon_sensor_update_policy_name
+- name: Build Sensor Update Policy Block (Linux)
+  when:
+    - falcon_sensor_update_policy_name
+    - falcon_sensor_update_policy_platform == 'Linux'
   block:
     - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
       ansible.builtin.set_fact:
@@ -40,7 +42,33 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info
       no_log: "{{ falcon_api_enable_no_log }}"
+      run_once: yes
 
+- name: Build Sensor Update Policy Block (MacOS)
+  when:
+    - falcon_sensor_update_policy_name
+    - falcon_sensor_update_policy_platform == 'Mac'
+  block:
+    - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
+      ansible.builtin.set_fact:
+        falcon_sensor_update_policy_query: "{{ 'platform_name:\"' + falcon_sensor_update_policy_platform + '\"+name.raw:\"' + falcon_sensor_update_policy_name + '\"' }}"
+
+    - name: "CrowdStrike Falcon | Search for Sensor Update Policy"
+      ansible.builtin.uri:
+        url: "https://{{ falcon_cloud }}/policy/combined/sensor-update/v2?filter={{ falcon_sensor_update_policy_query | urlencode }}"
+        method: GET
+        return_content: true
+        headers:
+          authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+          Content-Type: application/json
+      register: falcon_sensor_update_policy_info
+      no_log: "{{ falcon_api_enable_no_log }}"
+      run_once: yes
+
+- name: Sensor Update Policy Block
+  when:
+    - falcon_sensor_update_policy_name
+  block:
     - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
       ansible.builtin.fail:
         msg: "No Falcon Sensor Update Policy with name: {{ falcon_sensor_update_policy_name }} was found!"

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -13,6 +13,7 @@
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: yes
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -24,6 +24,7 @@
 
 # Block when falcon_sensor_update_policy_name is supplied
 - name: Sensor Update Policy Block
+  when: falcon_sensor_update_policy_name
   block:
     - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
       ansible.builtin.set_fact:
@@ -66,8 +67,6 @@
       ansible.builtin.set_fact:
         falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_update_policy_package_version + '\"' }}"
 
-  when: falcon_sensor_update_policy_name
-
 - name: "CrowdStrike Falcon | Build API Sensor Query"
   ansible.builtin.set_fact:
     falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + falcon_os_arch + '+version:\"' + falcon_sensor_version + '\"'
@@ -92,6 +91,7 @@
 
 # Block for checking sensor/kernel compatibility
 - name: Sensor Kernel Compatability Block
+  when: ansible_system == "Linux"
   block:
     - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
       ansible.builtin.set_fact:
@@ -127,7 +127,6 @@
         falcon_ztl_module_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].ztl_module_supported_sensor_versions }}"
       when: falcon_sensor_update_kernels_list.json.resources
       ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
-  when: ansible_system == "Linux"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.builtin.get_url:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -31,6 +31,7 @@
       Content-Type: application/json
   register: falcon_api_target_cid
   no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: yes
 
 # Block when falcon_sensor_update_policy_name is supplied
 - name: Sensor Update Policy Block
@@ -50,6 +51,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info
       no_log: "{{ falcon_api_enable_no_log }}"
+      run_once: yes
 
     - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
       ansible.builtin.fail:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -34,6 +34,7 @@
 
 # Block when falcon_sensor_update_policy_name is supplied
 - name: Sensor Update Policy Block
+  when: falcon_sensor_update_policy_name
   block:
     - name: "CrowdStrike Falcon | Build Sensor Update Policy API Query"
       ansible.builtin.set_fact:
@@ -62,7 +63,6 @@
     - name: "CrowdStrike Falcon | Build API Sensor Query based on Sensor Update Policy"
       ansible.builtin.set_fact:
         falcon_os_query: "{{ 'os:\"' + falcon_target_os + '\"+os_version:\"' + falcon_os_version + '\"+version:\"' + falcon_sensor_update_policy_package_version + '\"' }}"
-  when: falcon_sensor_update_policy_name
 
 - name: "CrowdStrike Falcon | Build API Sensor Query"
   ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -12,6 +12,7 @@
       content-type: "application/x-www-form-urlencoded; charset=utf-8"
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: yes
 
 - name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
   ansible.builtin.set_fact:


### PR DESCRIPTION
fixes #260 

In response to issue #260 - The idea here is to utilize the run_once ansible playbook keyword to prevent multiple API calls on tasks where it makes sense, such as:

- Authentication to API
- Sensor Update Policy

What run_once is:
> Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.

So basically this will only run the task on one host, and use that output for the other hosts (think bearer token or sensor update policy sensor version)

Also in this PR is updates to new Ansible-lint rules and pre-commit changes.
