### PR TITLE
Update workflows due to runner issues

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request_target' &&
       github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request_target' &&
       github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request_target' &&
       github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        continue-on-error: true
+        continue-on-error: false
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        continue-on-error: true
+        continue-on-error: false
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-galaxy collection install $collection_file
 
       - name: Run role tests
-        continue-on-error: true
+        continue-on-error: false
         run: >-
           molecule --version &&
           ansible --version &&

--- a/roles/falcon_install/tasks/win_install.yml
+++ b/roles/falcon_install/tasks/win_install.yml
@@ -27,7 +27,7 @@
   changed_when: no
 
 - name: CrowdStrike Falcon | Remove tmp install directory (Windows)
-  ansible.builtin.win_file:
+  ansible.windows.win_file:
     path: "{{ item.path }}"
     state: absent
   loop: "{{ falcon_tmp_dir_objects.files }}"


### PR DESCRIPTION
This PR addresses:

- The Linux CI jobs were failing whenever a job was launched on ubuntu 22.04 runner. GH is in the middle of transitioning the `ubuntu-latest` tag from 20.04 to 22.04 so that is why this is a random failing event. We will use 20.04 until we figure out why 22.04 does not work the same way.
- Fixed an Ansible lint issue for the Windows jobs. Updated the Windows workflows to fail instead of continuing on error.