### PR TITLE
Refactored API authentication for better use-ability

### DIFF
--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -6,7 +6,9 @@
     - falcon_option_set
     - not falcon_cid
   block:
-    - ansible.builtin.include_tasks: api.yml
+    - ansible.builtin.include_role:
+        name: falcon_install
+        tasks_from: auth.yml
       # noqa name[missing]
 
 - name: Linux Configure block

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -1,27 +1,4 @@
 ---
-- name: CrowdStrike Falcon | Authenticate to CrowdStrike API
-  ansible.builtin.uri:
-    url: "https://{{ falcon_cloud }}/oauth2/token"
-    method: POST
-    body_format: json
-    body:
-      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
-    return_content: true
-    follow_redirects: all
-    status_code: 201
-    headers:
-      content-type: application/x-www-form-urlencoded
-  register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: yes
-
-- name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
-  ansible.builtin.set_fact:
-      falcon_cloud: "{{ falcon_cloud_urls[falcon_api_oauth2_token.x_cs_region] }}"
-  when:
-    - falcon_cloud_autodiscover
-    - falcon_api_oauth2_token.x_cs_region | length > 0
-
 # Block when falcon_sensor_update_policy_name is supplied
 - name: Build Sensor Update Policy Block (Linux)
   when:

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -14,6 +14,7 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
   run_once: yes
+  delegate_to: localhost
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -22,18 +23,22 @@
     - falcon_cloud_autodiscover
     - falcon_api_oauth2_token.x_cs_region | length > 0
 
-- name: CrowdStrike Falcon | Detect Target CID Based on Credentials
-  ansible.builtin.uri:
-    url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
-    method: GET
-    return_content: true
-    headers:
-      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
-      Content-Type: application/json
-  register: falcon_api_target_cid
-  no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: yes
+- name: Set falcon_cid Block
+  when: not falcon_cid
+  block:
+  - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
+    ansible.builtin.uri:
+      url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
+      method: GET
+      return_content: true
+      headers:
+        authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+        Content-Type: application/json
+    register: falcon_api_target_cid
+    no_log: "{{ falcon_api_enable_no_log }}"
+    run_once: yes
+    delegate_to: localhost
 
-- name: CrowdStrike Falcon | Set CID received from API
-  ansible.builtin.set_fact:
-    falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"
+  - name: CrowdStrike Falcon | Set CID received from API
+    ansible.builtin.set_fact:
+      falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"

--- a/roles/falcon_install/tasks/main.yml
+++ b/roles/falcon_install/tasks/main.yml
@@ -18,6 +18,8 @@
     - falcon_install_method == "api"
     - ansible_os_family != "Windows"
   block:
+    - ansible.builtin.include_tasks: auth.yml
+      # noqa name[missing]
     - ansible.builtin.include_tasks: api.yml
       # noqa name[missing]
 
@@ -33,6 +35,8 @@
     - falcon_install_method == "api"
     - ansible_os_family == "Windows"
   block:
+    - ansible.builtin.include_tasks: auth.yml
+      # noqa name[missing]
     - ansible.builtin.include_tasks: win_api.yml
       # noqa name[missing]
 

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -1,38 +1,4 @@
 ---
-- name: CrowdStrike Falcon | Authenticate to CrowdStrike Cloud to Auto-discover Region
-  ansible.windows.win_uri:
-    url: "https://{{ falcon_cloud }}/oauth2/token"
-    method: POST
-    body:
-      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
-    return_content: true
-    follow_redirects: all
-    status_code: 201
-    headers:
-      content-type: "application/x-www-form-urlencoded; charset=utf-8"
-  register: falcon_api_oauth2_token
-  no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: yes
-
-- name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
-  ansible.builtin.set_fact:
-      falcon_cloud: "{{ falcon_cloud_urls[falcon_api_oauth2_token.x_cs_region] }}"
-  when:
-    - falcon_cloud_autodiscover
-    - falcon_api_oauth2_token.x_cs_region | length > 0
-
-- name: CrowdStrike Falcon | Detect Target CID Based on Credentials
-  ansible.windows.win_uri:
-    url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
-    method: GET
-    return_content: true
-    headers:
-      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
-      Content-Type: application/json
-  register: falcon_api_target_cid
-  no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: yes
-
 # Block when falcon_sensor_update_policy_name is supplied
 - name: Sensor Update Policy Block
   when: falcon_sensor_update_policy_name
@@ -99,11 +65,6 @@
   changed_when: false
   register: falcon_sensor_download
   no_log: "{{ falcon_api_enable_no_log }}"
-
-- name: CrowdStrike Falcon | Set CID received from API
-  ansible.builtin.set_fact:
-    falcon_cid: "{{ falcon_api_target_cid.json.resources[0] }}"
-  when: not falcon_cid
 
 - name: CrowdStrike Falcon | Set full file download path
   ansible.builtin.set_fact:


### PR DESCRIPTION
closes #271 #272 

This PR introduces the following changes:

- falcon_install
  - Create new `auth.yml` file to handle api authentication, irregardless of operating system
  - Add new include_task: auth.yml to both API blocks 
- falcon_configure
  - Replace `api.yml` task by including the new `auth.yml` from the falcon_install role