### PR TITLE
Bump version to 3.2.26

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ Ansible CrowdStrike Falcon Collection Release Notes
 .. contents:: Topics
 
 
+v3.2.26
+=======
+
+Release Summary
+---------------
+
+| Release Date: 2022-12-27
+| `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.2.26>`__
+
+
+Bugfixes
+--------
+
+- falcon_install - Fix issue with non-linux systems being affected by `falcon_os_arch` variable (https://github.com/CrowdStrike/ansible_collection_falcon/pull/284)
+
 v3.2.25
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -110,3 +110,17 @@ releases:
     - 3.2.25.yml
     - fixes.yml
     release_date: '2022-12-22'
+  3.2.26:
+    changes:
+      bugfixes:
+      - falcon_install - Fix issue with non-linux systems being affected by `falcon_os_arch`
+        variable (https://github.com/CrowdStrike/ansible_collection_falcon/pull/284)
+      release_summary: '| Release Date: 2022-12-27
+
+        | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.2.26>`__
+
+        '
+    fragments:
+    - 3.2.26-summary.yml
+    - bugfixes.yml
+    release_date: '2022-12-27'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.25
+version: 3.2.26
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Includes fix for non-linux systems for determining arch for sensor queries.