### PR TITLE
Changes to fix broken CI

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint
+          pip install molecule[lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[lint] ansible yamllint ansible-lint
+          pip install molecule[docker,lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint
+          pip install molecule[lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[lint] ansible yamllint ansible-lint
+          pip install molecule[docker,lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[docker,lint,ansible] ansible yamllint ansible-lint
+          pip install molecule[lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sudo apt install apt-transport-https ca-certificates curl software-properties-common
           python -m pip install --upgrade pip
-          pip install molecule[lint] ansible yamllint ansible-lint
+          pip install molecule[docker,lint] ansible yamllint ansible-lint
 
       - name: Build/Install the collection
         run: |

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -27,13 +27,12 @@ jobs:
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
       FALCON_CID: ${{ secrets.FALCON_CID }}
+      FALCON_PROV_TOKEN: ${{ secrets.FALCON_PROV_TOKEN }}
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: YES
     strategy:
       fail-fast: false
       matrix:
         molecule_distro:
-          # - { "distro":"WindowsServer2012R2" }
-          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_configure
@@ -47,12 +46,6 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.sha}}
         if: github.event_name == 'pull_request_target'
-
-      - name: Cache Vagrant boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/jborean93-VAGRANTSLASH-${{ matrix.molecule_distro.distro }}
-          key: ${{ runner.os }}-${{ matrix.molecule_distro.distro }}-${{ matrix.collection_role }}-${{ hashFiles('molecule/win_falcon_configure/molecule.yml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -27,13 +27,12 @@ jobs:
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
       FALCON_CID: ${{ secrets.FALCON_CID }}
+      FALCON_PROV_TOKEN: ${{ secrets.FALCON_PROV_TOKEN }}
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: YES
     strategy:
       fail-fast: false
       matrix:
         molecule_distro:
-          # - { "distro":"WindowsServer2012R2" }
-          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_install
@@ -47,12 +46,6 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.sha}}
         if: github.event_name == 'pull_request_target'
-
-      - name: Cache Vagrant boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/jborean93-VAGRANTSLASH-${{ matrix.molecule_distro.distro }}
-          key: ${{ runner.os }}-${{ matrix.molecule_distro.distro }}-${{ matrix.collection_role }}-${{ hashFiles('molecule/win_falcon_install/molecule.yml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -27,13 +27,12 @@ jobs:
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
       FALCON_CID: ${{ secrets.FALCON_CID }}
+      FALCON_PROV_TOKEN: ${{ secrets.FALCON_PROV_TOKEN }}
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: YES
     strategy:
       fail-fast: false
       matrix:
         molecule_distro:
-          # - { "distro":"WindowsServer2012R2" }
-          # - { "distro":"WindowsServer2016" }
           - { "distro":"WindowsServer2019" }
         collection_role:
           - falcon_uninstall
@@ -47,12 +46,6 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.sha}}
         if: github.event_name == 'pull_request_target'
-
-      - name: Cache Vagrant boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes/jborean93-VAGRANTSLASH-${{ matrix.molecule_distro.distro }}
-          key: ${{ runner.os }}-${{ matrix.molecule_distro.distro }}-${{ matrix.collection_role }}-${{ hashFiles('molecule/win_falcon_uninstall/molecule.yml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/molecule/falcon_configure/cleanup.yml
+++ b/molecule/falcon_configure/cleanup.yml
@@ -1,4 +1,0 @@
-- name: Cleanup
-  hosts: all
-  roles:
-    - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/falcon_configure/converge.yml
+++ b/molecule/falcon_configure/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  become: yes
   vars:
     falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
@@ -13,6 +14,7 @@
         falcon_tags: 'falcon,example,tags'
         falcon_billing: 'metered'
         falcon_message_log: yes
+        falcon_backend: 'kernel'
         falcon_feature:
           - enableLog
           - disableLogBuffer

--- a/molecule/falcon_configure/molecule.yml
+++ b/molecule/falcon_configure/molecule.yml
@@ -31,5 +31,4 @@ scenario:
     - idempotence
     - side_effect
     - verify
-    - cleanup
     - destroy

--- a/molecule/falcon_configure/prepare.yml
+++ b/molecule/falcon_configure/prepare.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prepare
   hosts: all
+  become: yes
   tasks:
     # Ubuntu specific
     - name: Install apt dependencies

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -3,6 +3,7 @@
 
 - name: Verify
   hosts: all
+  become: yes
   tasks:
   - name: Get list of Falcon Sensor Options
     crowdstrike.falcon.falconctl_info:
@@ -11,7 +12,6 @@
   - name: Verify Falcon Sensor options are set
     ansible.builtin.assert:
       that:
-        - info.falconctl_info.aid
         - info.falconctl_info.cid
         - info.falconctl_info.billing
         - info.falconctl_info.tags
@@ -52,26 +52,29 @@
       falcon_aph: ""
       falcon_app: ""
 
-  - name: Test Deleting AID master image prep
-    ansible.builtin.include_role:
-      name: crowdstrike.falcon.falcon_configure
-    vars:
-      falcon_option_set: no
-      falcon_remove_aid: yes
+  - name: AID deletion block
+    when: info.falconctl_info.aid
+    block:
+      - name: Test Deleting AID master image prep
+        ansible.builtin.include_role:
+          name: crowdstrike.falcon.falcon_configure
+        vars:
+          falcon_option_set: no
+          falcon_remove_aid: yes
 
-  - name: Get Updated Falcon Sensor Option
-    crowdstrike.falcon.falconctl_info:
-    register: delete_info
+      - name: Get Updated Falcon Sensor Option
+        crowdstrike.falcon.falconctl_info:
+        register: delete_info
 
-  - name: Verify Falcon Sensor options are not set
-    ansible.builtin.assert:
-      that:
-        - not delete_info.falconctl_info.aid
-        - not delete_info.falconctl_info.cid
-        - not delete_info.falconctl_info.tags
-        - not delete_info.falconctl_info.apd
-        - not delete_info.falconctl_info.aph
-        - not delete_info.falconctl_info.app
+      - name: Verify Falcon Sensor options are not set
+        ansible.builtin.assert:
+          that:
+            - not delete_info.falconctl_info.aid
+            - not delete_info.falconctl_info.cid
+            - not delete_info.falconctl_info.tags
+            - not delete_info.falconctl_info.apd
+            - not delete_info.falconctl_info.aph
+            - not delete_info.falconctl_info.app
 
   - name: Test auto-detecting CID
     ansible.builtin.include_role:

--- a/molecule/falcon_install/cleanup.yml
+++ b/molecule/falcon_install/cleanup.yml
@@ -1,4 +1,0 @@
-- name: Cleanup
-  hosts: all
-  roles:
-    - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/falcon_install/converge.yml
+++ b/molecule/falcon_install/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  become: yes
   vars:
     falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"

--- a/molecule/falcon_install/molecule.yml
+++ b/molecule/falcon_install/molecule.yml
@@ -31,5 +31,4 @@ scenario:
     - idempotence
     - side_effect
     - verify
-    - cleanup
     - destroy

--- a/molecule/falcon_install/prepare.yml
+++ b/molecule/falcon_install/prepare.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prepare
   hosts: all
+  become: yes
   tasks:
     # Ubuntu specific
     - name: Install apt dependencies

--- a/molecule/falcon_install/verify.yml
+++ b/molecule/falcon_install/verify.yml
@@ -3,6 +3,7 @@
 
 - name: Verify
   hosts: all
+  become: yes
   tasks:
   - name: Get list of installed packages
     ansible.builtin.package_facts:

--- a/molecule/falcon_uninstall/converge.yml
+++ b/molecule/falcon_uninstall/converge.yml
@@ -1,5 +1,6 @@
 ---
 - name: Converge
   hosts: all
+  become: yes
   roles:
     - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/falcon_uninstall/prepare.yml
+++ b/molecule/falcon_uninstall/prepare.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prepare
   hosts: all
+  become: yes
   tasks:
     # Ubuntu specific
     - name: Install apt dependencies

--- a/molecule/falcon_uninstall/verify.yml
+++ b/molecule/falcon_uninstall/verify.yml
@@ -3,6 +3,7 @@
 
 - name: Verify
   hosts: all
+  become: yes
   tasks:
   - name: Get list of installed packages
     ansible.builtin.package_facts:

--- a/molecule/win_falcon_configure/cleanup.yml
+++ b/molecule/win_falcon_configure/cleanup.yml
@@ -1,4 +1,0 @@
-- name: Cleanup
-  hosts: all
-  roles:
-    - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/win_falcon_configure/molecule.yml
+++ b/molecule/win_falcon_configure/molecule.yml
@@ -7,7 +7,7 @@ driver:
     name: virtualbox
 platforms:
   - name: falcon
-    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2016}"
+    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
     box_version: 1.0.0
     memory: 4096
     cpus: 2
@@ -44,5 +44,4 @@ scenario:
     - idempotence
     - side_effect
     - verify
-    - cleanup
     - destroy

--- a/molecule/win_falcon_configure/prepare.yml
+++ b/molecule/win_falcon_configure/prepare.yml
@@ -2,9 +2,15 @@
 - name: Prepare
   hosts: all
   tasks:
+    - name: Set ProvToken info (if applicable)
+      set_fact:
+        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+      when: lookup('env', 'FALCON_PROV_TOKEN')
+
     - name: Install Falcon Sensor
       ansible.builtin.include_role:
         name: crowdstrike.falcon.falcon_install
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"

--- a/molecule/win_falcon_install/cleanup.yml
+++ b/molecule/win_falcon_install/cleanup.yml
@@ -1,4 +1,0 @@
-- name: Cleanup
-  hosts: all
-  roles:
-    - role: crowdstrike.falcon.falcon_uninstall

--- a/molecule/win_falcon_install/converge.yml
+++ b/molecule/win_falcon_install/converge.yml
@@ -1,8 +1,16 @@
 ---
 - name: Converge
   hosts: all
-  vars:
-    falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
-    falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
-  roles:
-    - role: crowdstrike.falcon.falcon_install
+  tasks:
+    - name: Set ProvToken info (if applicable)
+      set_fact:
+        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+      when: lookup('env', 'FALCON_PROV_TOKEN')
+
+    - name: Install Falcon Sensor
+      ansible.builtin.include_role:
+        name: crowdstrike.falcon.falcon_install
+      vars:
+        falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+        falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"

--- a/molecule/win_falcon_install/molecule.yml
+++ b/molecule/win_falcon_install/molecule.yml
@@ -7,7 +7,7 @@ driver:
     name: virtualbox
 platforms:
   - name: falcon
-    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2016}"
+    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
     box_version: 1.0.0
     memory: 4096
     cpus: 2
@@ -44,5 +44,4 @@ scenario:
     - idempotence
     - side_effect
     - verify
-    - cleanup
     - destroy

--- a/molecule/win_falcon_uninstall/molecule.yml
+++ b/molecule/win_falcon_uninstall/molecule.yml
@@ -7,7 +7,7 @@ driver:
     name: virtualbox
 platforms:
   - name: falcon
-    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2016}"
+    box: "jborean93/${MOLECULE_DISTRO:-WindowsServer2019}"
     box_version: 1.0.0
     memory: 4096
     cpus: 2
@@ -44,5 +44,4 @@ scenario:
     - idempotence
     - side_effect
     - verify
-    - cleanup
     - destroy

--- a/molecule/win_falcon_uninstall/prepare.yml
+++ b/molecule/win_falcon_uninstall/prepare.yml
@@ -2,9 +2,15 @@
 - name: Prepare
   hosts: all
   tasks:
+    - name: Set ProvToken info (if applicable)
+      set_fact:
+        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+      when: lookup('env', 'FALCON_PROV_TOKEN')
+
     - name: Install Falcon Sensor
       ansible.builtin.include_role:
         name: crowdstrike.falcon.falcon_install
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -14,7 +14,7 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
   run_once: yes
-  delegate_to: localhost
+  delegate_to: "{{ 'localhost' if ansible_system != 'Linux' else omit }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -37,7 +37,7 @@
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
     run_once: yes
-    delegate_to: localhost
+    delegate_to: "{{ 'localhost' if ansible_system != 'Linux' else omit }}"
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:


### PR DESCRIPTION
This PR introduces changes associated with fixing issues causing our CI jobs to fail. Some of these changes are in support of the new backend kernel option which makes `aid` acquisition trickier from a CI perspective. A follow up PR #287 for adding changes to support that option will follow.