### PR TITLE
Ensure plays are named - per ansible-lint

### DIFF
--- a/roles/falcon_configure/tests/test.yml
+++ b/roles/falcon_configure/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Configure Falcon Sensor
+  hosts: localhost
   remote_user: root
   roles:
     - falcon_configure

--- a/roles/falcon_uninstall/tests/test.yml
+++ b/roles/falcon_uninstall/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Uninstall Falcon
+  hosts: localhost
   remote_user: root
   roles:
     - falcon_uninstall

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Install, configure, and uninstall the Falcon Sensor
+  hosts: localhost
   remote_user: root
   vars:
     falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"


### PR DESCRIPTION
Fixes the following Ansible Lint errors:
```terminal
name[play]: All plays should be named.
roles/falcon_configure/tests/test.yml:2

name[play]: All plays should be named.
roles/falcon_uninstall/tests/test.yml:2

name[play]: All plays should be named.
tests/test.yml:2

You can skip specific rules or tags by adding them to your configuration file:
# .config/ansible-lint.yml
warn_list:  # or 'skip_list' to silence them completely
  - name[play]  # Rule for checking task and play names.

            Rule Violation Summary
 count tag        profile rule associated tags
     3 name[play] basic   idiom
```