### PR TITLE
Update ansible facts to use dictionary as opposed to magic name

### DIFF
--- a/molecule/falcon_configure/prepare.yml
+++ b/molecule/falcon_configure/prepare.yml
@@ -10,7 +10,7 @@
           - gpg-agent
         update_cache: yes
       ignore_errors: yes
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Install dependencies
       ansible.builtin.package:

--- a/molecule/falcon_install/prepare.yml
+++ b/molecule/falcon_install/prepare.yml
@@ -10,7 +10,7 @@
           - gpg-agent
         update_cache: yes
       ignore_errors: yes
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Install dependencies
       package:

--- a/molecule/falcon_install_policy/prepare.yml
+++ b/molecule/falcon_install_policy/prepare.yml
@@ -9,7 +9,7 @@
           - gpg-agent
         update_cache: yes
       ignore_errors: yes
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Install dependencies
       package:

--- a/molecule/falcon_uninstall/prepare.yml
+++ b/molecule/falcon_uninstall/prepare.yml
@@ -10,7 +10,7 @@
           - gpg-agent
         update_cache: yes
       ignore_errors: yes
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Install dependencies
       ansible.builtin.package:

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: Linux Block
-  when: ansible_distribution != "MacOSX"
+  when: ansible_facts['distribution'] != "MacOSX"
   block:
     - name: CrowdStrike Falcon | Configure Falcon Sensor Options (Linux)
       crowdstrike.falcon.falconctl:
@@ -33,7 +33,7 @@
       become: yes
 
 - name: MacOSX Block
-  when: ansible_distribution == "MacOSX"
+  when: ansible_facts['distribution'] == "MacOSX"
   block:
     - name: CrowdStrike Falcon | Associate Falcon Sensor with your Customer ID (CID) (macOS)
       ansible.builtin.command: "/Applications/Falcon.app/Contents/Resources/falconctl license {{ falcon_cid }}"

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Linux Configure block
   when:
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
     - not falcon_remove_aid
   become: true
   become_user: root
@@ -24,14 +24,14 @@
 - name: Remove AID block
   when:
     - falcon_remove_aid
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
   block:
     - ansible.builtin.include_tasks: remove_aid.yml
       # noqa name[missing]
 
 - name: Windows block
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
   become: true
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -61,17 +61,17 @@
         msg: "No Falcon Sensor Update Policy with name: {{ falcon_sensor_update_policy_name }} and enabled for aarch64 was found!"
       when:
         - falcon_sensor_update_policy_info.json.resources[0].settings.variants[0] is not defined
-        - ansible_machine == "aarch64"
+        - ansible_facts['machine'] == "aarch64"
 
     - name: "CrowdStrike Falcon | Get the Falcon Sensor version from Update Policy"
       ansible.builtin.set_fact:
         falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.json.resources[0].settings.sensor_version }}"
-      when: ansible_machine != "aarch64"
+      when: ansible_facts['machine'] != "aarch64"
 
     - name: "CrowdStrike Falcon | Get the Falcon Sensor version from Update Policy for aarch64 architecture"
       ansible.builtin.set_fact:
         falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.json.resources[0].settings.variants[0].sensor_version }}"
-      when: ansible_machine == "aarch64"
+      when: ansible_facts['machine'] == "aarch64"
 
     - name: "CrowdStrike Falcon | Build API Sensor Query based on Sensor Update Policy"
       ansible.builtin.set_fact:
@@ -101,11 +101,11 @@
 
 # Block for checking sensor/kernel compatibility
 - name: Sensor Kernel Compatability Block
-  when: ansible_system == "Linux"
+  when: ansible_facts['system'] == "Linux"
   block:
     - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
       ansible.builtin.set_fact:
-        falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_kernel + '\"' }}"
+        falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_facts['kernel'] + '\"' }}"
 
     - name: CrowdStrike Falcon | Get list of Supported Kernels
       ansible.builtin.uri:
@@ -121,7 +121,7 @@
     - name: CrowdStrike Falcon | Validate Kernel is Supported
       ansible.builtin.assert:
         that: falcon_sensor_update_kernels_list.json.resources
-        fail_msg: "The kernel version: {{ ansible_kernel }} is not supported by the Falcon Sensor!"
+        fail_msg: "The kernel version: {{ ansible_facts['kernel'] }} is not supported by the Falcon Sensor!"
       ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
 
     - name: CrowdStrike Falcon | Validate Sensor version is compatible with Kernel
@@ -129,7 +129,7 @@
         that: falcon_sensor_version in falcon_base_package_supported_sensor_versions or
               falcon_sensor_version in falcon_ztl_supported_sensor_versions or
               falcon_sensor_version in falcon_ztl_module_supported_sensor_versions
-        fail_msg: "The sensor version: {{ falcon_sensor_version }} is not supported with kernel: {{ ansible_kernel }}"
+        fail_msg: "The sensor version: {{ falcon_sensor_version }} is not supported with kernel: {{ ansible_facts['kernel'] }}"
       vars:
         falcon_sensor_version: "{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].version }}"
         falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].base_package_supported_sensor_versions }}"

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -14,7 +14,7 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
   run_once: yes
-  delegate_to: "{{ 'localhost' if ansible_system != 'Linux' else omit }}"
+  delegate_to: "{{ 'localhost' if ansible_facts['system'] != 'Linux' else omit }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -37,7 +37,7 @@
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
     run_once: yes
-    delegate_to: "{{ 'localhost' if ansible_system != 'Linux' else omit }}"
+    delegate_to: "{{ 'localhost' if ansible_facts['system'] != 'Linux' else omit }}"
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/install.yml
+++ b/roles/falcon_install/tasks/install.yml
@@ -21,7 +21,7 @@
   changed_when: no
   when:
     - falcon_gpg_key_check
-    - ansible_pkg_mgr in rpm_packagers
+    - ansible_facts['pkg_mgr'] in rpm_packagers
 
 - name: CrowdStrike Falcon | Import CrowdStrike Falcon APT GPG key from file
   ansible.builtin.apt_key:
@@ -30,27 +30,27 @@
   changed_when: no
   when:
     - falcon_gpg_key_check
-    - ansible_pkg_mgr in dpkg_packagers
+    - ansible_facts['pkg_mgr'] in dpkg_packagers
 
 - name: CrowdStrike Falcon | Install Falcon Sensor Package (Linux)
   ansible.builtin.package:
-    deb: "{{ falcon_sensor_pkg if (ansible_pkg_mgr in dpkg_packagers) else omit }}"
-    name: "{{ falcon_sensor_pkg if (ansible_pkg_mgr in rpm_packagers) else omit }}"
+    deb: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in dpkg_packagers) else omit }}"
+    name: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in rpm_packagers) else omit }}"
     state: present
   when:
-    - ansible_pkg_mgr in linux_packagers
+    - ansible_facts['pkg_mgr'] in linux_packagers
 
 - name: CrowdStrike Falcon | Install Falcon Sensor .pkg Package (macOS)
   ansible.builtin.command: "/usr/sbin/installer -pkg {{ falcon_sensor_pkg }} -target /"
   args:
     creates: "/Applications/Falcon.app/Contents/Resources/falconctl"
   when:
-    - ansible_distribution == "MacOSX"
+    - ansible_facts['distribution'] == "MacOSX"
 
 - name: CrowdStrike Falcon | Verify Falcon Package Is Installed
   ansible.builtin.package_facts:
     manager: auto
-  when: ansible_distribution != "MacOSX"
+  when: ansible_facts['distribution'] != "MacOSX"
 
 - name: CrowdStrike Falcon | Gather tmp install directory objects
   ansible.builtin.find:

--- a/roles/falcon_install/tasks/main.yml
+++ b/roles/falcon_install/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: URL block
   when:
     - falcon_install_method == "url"
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
   block:
     - ansible.builtin.include_tasks: url.yml
       # noqa name[missing]
@@ -16,7 +16,7 @@
 - name: API block
   when:
     - falcon_install_method == "api"
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
   block:
     - ansible.builtin.include_tasks: auth.yml
       # noqa name[missing]
@@ -33,7 +33,7 @@
 - name: Windows API block
   when:
     - falcon_install_method == "api"
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
   block:
     - ansible.builtin.include_tasks: auth.yml
       # noqa name[missing]
@@ -42,7 +42,7 @@
 
 - name: Non-Windows Install block
   when:
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
   become: true
   become_user: root
   block:
@@ -51,7 +51,7 @@
 
 - name: Windows Install block
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
   become: true
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -26,31 +26,31 @@
   ansible.builtin.set_fact:
     ansible_python_interpreter: /usr/bin/python
   when:
-    - ansible_distribution == "Amazon"
-    - ansible_distribution_major_version | int < 2
+    - ansible_facts['distribution'] == "Amazon"
+    - ansible_facts['distribution_major_version'] | int < 2
 
 - name: "CrowdStrike Falcon | Default Operating System configuration"
   ansible.builtin.set_fact:
-    falcon_target_os: "{{ ansible_distribution }}"
-    falcon_os_family: "{{ ansible_system | lower }}"
-    falcon_os_version: "*{{ ansible_distribution_major_version }}*"
-    falcon_sensor_update_policy_platform: "{{ ansible_system }}"
-    falcon_os_vendor: "{{ ansible_os_family | lower if (ansible_os_family == 'RedHat' and ansible_distribution != 'Amazon') else ansible_distribution | lower }}"
+    falcon_target_os: "{{ ansible_facts['distribution'] }}"
+    falcon_os_family: "{{ ansible_facts['system'] | lower }}"
+    falcon_os_version: "*{{ ansible_facts['distribution_major_version'] }}*"
+    falcon_sensor_update_policy_platform: "{{ ansible_facts['system'] }}"
+    falcon_os_vendor: "{{ ansible_facts['os_family'] | lower if (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Amazon') else ansible_facts['distribution'] | lower }}"
 
 - name: "CrowdStrike Falcon | Determine Operating System Architecture (Linux)"
   ansible.builtin.set_fact:
-    falcon_os_arch: "{{ falcon_os_arch_dict[ansible_architecture] }}"
-  when: ansible_system == "Linux"
+    falcon_os_arch: "{{ falcon_os_arch_dict[ansible_facts['architecture']] }}"
+  when: ansible_facts['system'] == "Linux"
 
 - name: "CrowdStrike Falcon | Determine if Endpoint Operating System Is RHEL, CentOS, or Oracle Linux"
   ansible.builtin.set_fact:
     falcon_target_os: "*RHEL*"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: "CrowdStrike Falcon | Determine if Target OS Is Amazon Linux"
   ansible.builtin.set_fact:
     falcon_target_os: "Amazon Linux"
-  when: ansible_distribution == "Amazon"
+  when: ansible_facts['distribution'] == "Amazon"
 
 - name: CrowdStrike Falcon | Determine if Target OS Is MacOS
   ansible.builtin.set_fact:
@@ -59,14 +59,14 @@
     falcon_path: "/Applications/Falcon.app/Contents/Resources/"
     falcon_os_version: ""
     falcon_sensor_update_policy_platform: "{{ falcon_os_family | capitalize }}"
-  when: ansible_distribution == "MacOSX"
+  when: ansible_facts['distribution'] == "MacOSX"
 
 - name: "CrowdStrike Falcon | Endpoint Operating System Detected Is Microsoft Windows"
   ansible.builtin.set_fact:
     falcon_os_version: ""
     falcon_target_os: "Windows"
-    falcon_sensor_update_policy_platform: "{{ ansible_os_family }}"
-  when: ansible_os_family == "Windows"
+    falcon_sensor_update_policy_platform: "{{ ansible_facts['os_family'] }}"
+  when: ansible_facts['os_family'] == "Windows"
 
 - name: CrowdStrike Falcon | Verify Temporary Install Directory Exists (non-Windows)
   ansible.builtin.tempfile:
@@ -74,7 +74,7 @@
     state: directory
     suffix: falcon
   when:
-    - ansible_system == "Linux" or ansible_system == "Darwin"
+    - ansible_facts['system'] == "Linux" or ansible_facts['system'] == "Darwin"
     - falcon_install_tmp_dir is defined
   register: falcon_install_temp_directory
   changed_when: no
@@ -85,7 +85,7 @@
     state: directory
     suffix: falcon
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
     - falcon_windows_tmp_dir is defined
   register: falcon_install_win_temp_directory
   changed_when: no
@@ -94,7 +94,7 @@
   ansible.builtin.stat:
     path: "{{ falcon_path }}"
   when:
-    - ansible_system == "Darwin"
+    - ansible_facts['system'] == "Darwin"
     - falcon_path is defined
   register: falcon_already_installed
 

--- a/roles/falcon_install/tasks/win_install.yml
+++ b/roles/falcon_install/tasks/win_install.yml
@@ -6,7 +6,7 @@
     creates_service: csfalconservice
     arguments: '/install /quiet CID={{ falcon_cid }} {{ falcon_windows_install_args }}'
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
   register: falcon_installed
   retries: "{{ falcon_windows_install_retries }}"
   delay: "{{ falcon_windows_install_delay }}"

--- a/roles/falcon_uninstall/tasks/main.yml
+++ b/roles/falcon_uninstall/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for falcon_uninstall
 - name: Linux Block
   when:
-    - ansible_os_family != "Windows"
+    - ansible_facts['os_family'] != "Windows"
   become: true
   become_user: root
   block:
@@ -11,7 +11,7 @@
 
 - name: Windows Block
   when:
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"
   become: true
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"

--- a/roles/falcon_uninstall/tasks/uninstall.yml
+++ b/roles/falcon_uninstall/tasks/uninstall.yml
@@ -2,21 +2,21 @@
 - name: CrowdStrike Falcon | Determine if Falcon is installed (MacOS)
   ansible.builtin.stat:
     path: "/Applications/Falcon.app/Contents/Resources/falconctl"
-  when: ansible_distribution == "MacOSX"
+  when: ansible_facts['distribution'] == "MacOSX"
   register: falcon_already_installed
 
 - name: CrowdStrike Falcon | Uninstalling Falcon Sensor (Linux)
   ansible.builtin.package:
     name: falcon-sensor
     state: absent
-    purge: "{{ True if (ansible_pkg_mgr == 'apt') else omit }}"
+    purge: "{{ True if (ansible_facts['pkg_mgr'] == 'apt') else omit }}"
   when:
-    - ansible_system == "Linux"
+    - ansible_facts['system'] == "Linux"
 
 - name: MacOS Block
   when:
     - falcon_already_installed is defined
-    - ansible_system == "Darwin"
+    - ansible_facts['system'] == "Darwin"
   block:
     - name: CrowdStrike Falcon | Stopping Falcon Sensor (macOS)
       ansible.builtin.command: "launchctl stop com.crowdstrike.falcond"

--- a/roles/falcon_uninstall/tasks/win_uninstall.yml
+++ b/roles/falcon_uninstall/tasks/win_uninstall.yml
@@ -15,4 +15,4 @@
     arguments: '/uninstall /quiet {{ falcon_windows_uninstall_args }}'
   when:
     - falcon_win_sensor_cache.files | length > 0
-    - ansible_os_family == "Windows"
+    - ansible_facts['os_family'] == "Windows"


### PR DESCRIPTION
Closes #298 

This PR provides a more compatible way of using ansible facts. By default, as of Ansible 2.5 they have allowed facts to be used with a top-level naming schema of: ansible_<facts>

Down the road, this will eventually be shifted to use the ansible_facts dictionary to prevent collisions with other modules that may use ansible_* naming conventions.