### PR TITLE
Fix delegate_to and potential omit bug

### DIFF
--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -14,7 +14,8 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
   run_once: yes
-  delegate_to: "{{ 'localhost' if ansible_facts['system'] != 'Linux' else omit }}"
+  delegate_to: localhost
+  become: false
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -37,7 +38,8 @@
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
     run_once: yes
-    delegate_to: "{{ 'localhost' if ansible_facts['system'] != 'Linux' else omit }}"
+    delegate_to: localhost
+    become: false
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:


### PR DESCRIPTION
This PR is trying to address an Ansible issue from #300 and issues associated to localhost delegation. Idea is to revert back to using `delegate_to: localhost` to prevent having to use omit keyword, and ensure the task(s) don't need to privilege (sudo). 

Hopefully fixed #305 