### PR TITLE
Extracts windows auth into own file for better support

### DIFF
--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - ansible.builtin.include_role:
         name: falcon_install
-        tasks_from: auth.yml
+        tasks_from: "{{ 'win_auth.yml' if ansible_facts['os_family'] == 'Windows' else 'auth.yml' }}"
       # noqa name[missing]
 
 - name: Linux Configure block

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -14,8 +14,6 @@
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
   run_once: yes
-  delegate_to: localhost
-  become: false
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -38,8 +36,6 @@
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
     run_once: yes
-    delegate_to: localhost
-    become: false
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/main.yml
+++ b/roles/falcon_install/tasks/main.yml
@@ -35,7 +35,7 @@
     - falcon_install_method == "api"
     - ansible_facts['os_family'] == "Windows"
   block:
-    - ansible.builtin.include_tasks: auth.yml
+    - ansible.builtin.include_tasks: win_auth.yml
       # noqa name[missing]
     - ansible.builtin.include_tasks: win_api.yml
       # noqa name[missing]

--- a/roles/falcon_install/tasks/win_auth.yml
+++ b/roles/falcon_install/tasks/win_auth.yml
@@ -1,0 +1,64 @@
+---
+- name: CrowdStrike Falcon | Authenticate to CrowdStrike API
+  ansible.windows.win_uri:
+    url: "https://{{ falcon_cloud }}/oauth2/token"
+    method: POST
+    body:
+      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
+    return_content: true
+    follow_redirects: all
+    status_code: [201, 308]
+    headers:
+      content-type: "application/x-www-form-urlencoded; charset=utf-8"
+  register: falcon_api_oauth2_token_win
+  no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: true
+
+- name: CrowdStrike Falcon | Configure discovered CrowdStrike Cloud Region
+  ansible.builtin.set_fact:
+      falcon_cloud: "{{ falcon_cloud_urls[falcon_api_oauth2_token_win.x_cs_region] }}"
+  when:
+    - falcon_cloud_autodiscover
+    - falcon_api_oauth2_token_win.x_cs_region | length > 0
+
+# With win_uri - the follow_redirects: all option does not work as expected.
+# The following task is a workaround to follow the redirect once we get a 308 response.
+- name: CrowdStrike Falcon | Authenticate to CrowdStrike API (follow redirect)
+  ansible.windows.win_uri:
+    url: "https://{{ falcon_cloud }}/oauth2/token"
+    method: POST
+    body:
+      "client_id={{ falcon_client_id }}&client_secret={{ falcon_client_secret }}"
+    return_content: true
+    follow_redirects: all
+    status_code: [201]
+    headers:
+      content-type: "application/x-www-form-urlencoded; charset=utf-8"
+  register: falcon_api_oauth2_token_win_redirect
+  no_log: "{{ falcon_api_enable_no_log }}"
+  run_once: true
+  when: falcon_api_oauth2_token_win.status_code == 308
+
+- name: CrowdStrike Falcon | Set Appropriate API OAuth2 Token
+  ansible.builtin.set_fact:
+    falcon_api_oauth2_token: "{{ falcon_api_oauth2_token_win_redirect if falcon_api_oauth2_token_win_redirect | length > 0 else falcon_api_oauth2_token_win }}"
+  no_log: "{{ falcon_api_enable_no_log }}"
+
+- name: Set falcon_cid Block
+  when: not falcon_cid
+  block:
+  - name: CrowdStrike Falcon | Detect Target CID Based on Credentials
+    ansible.windows.win_uri:
+      url: https://{{ falcon_cloud }}/sensors/queries/installers/ccid/v1
+      method: GET
+      return_content: true
+      headers:
+        authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+        Content-Type: application/json
+    register: falcon_api_target_cid_win
+    no_log: "{{ falcon_api_enable_no_log }}"
+    run_once: true
+
+  - name: CrowdStrike Falcon | Set CID received from API
+    ansible.builtin.set_fact:
+      falcon_cid: "{{ falcon_api_target_cid_win.json.resources[0] }}"


### PR DESCRIPTION
Originally the idea was to refactor all auth calls to localhost or nix* guests to take advantage of the more mature builtin.uri module. However, after some Ansible bugs in 2.12 were exposed around omitting args + some additional headaches around dealing with delegating to localhost when targeting Windows, this PR breaks auth apart for it's respective OS. For the Windows side, it also now handles following redirects when a 308 is encountered.