### PR TITLE
Adding variable to control run_once API option

### DIFF
--- a/changelogs/fragments/run-once-320.yml
+++ b/changelogs/fragments/run-once-320.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - falcon_install - made the ability to toggle run_once options available to the user (https://github.com/CrowdStrike/ansible_collection_falcon/pull/320)

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -14,6 +14,7 @@ Role Variables
 The following variables are currently supported:
 
  * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
+ * `falcon_api_enable_run_once` - Whether to enable or disable the run_once option for API calls. (bool, default: true)
  * `falcon_skip_kernel_compat_check` - Whether or not to ignore errors associated with unsupported Falcon Sensor/Kernel combination. (bool, default: false)
  * `falcon_install_method` - The installation method for installing the sensor (string, default: api)
  * `falcon_gpg_key` - Location of the Falcon GPG Key file (string, default: null)

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -14,7 +14,7 @@ Role Variables
 The following variables are currently supported:
 
  * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
- * `falcon_api_enable_run_once` - Whether to enable or disable the run_once option for API calls. (bool, default: true)
+ * `falcon_api_auth_run_once` - Whether to enable or disable the run_once option for API auth calls. (bool, default: true)
  * `falcon_skip_kernel_compat_check` - Whether or not to ignore errors associated with unsupported Falcon Sensor/Kernel combination. (bool, default: false)
  * `falcon_install_method` - The installation method for installing the sensor (string, default: api)
  * `falcon_gpg_key` - Location of the Falcon GPG Key file (string, default: null)
@@ -26,6 +26,7 @@ The following variables are currently supported:
  * `falcon_sensor_version` - Sensor version to install (string, default: null)
  * `falcon_sensor_version_decrement` - Sensor N-x version to install (int, default: 0 [latest])
  * `falcon_sensor_update_policy_name` - Sensor update policy used to control sensor version (string, default: null)
+ * `falcon_sensor_update_policy_run_once` - Whether to enable or disable the run_once option for Sensor update policy API calls. (bool, default: true)
  * `falcon_install_tmp_dir` - Temporary Linux and MacOS download and installation directory for the Falson Sensor (string, default: `/tmp/`)
  * `falcon_download_url` - URL for downloading the sensor (string, default: null)
  * `falcon_download_url_username` - username for downloading the sensor (string, default: null)

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -8,6 +8,11 @@
 #
 falcon_api_enable_no_log: yes
 
+# Whether or not to enable run_once for API calls.
+# By default, this is enabled.
+#
+falcon_api_enable_run_once: yes
+
 # Whether or not to ignore errors associated with unsupported Falcon Sensor Kernel
 # configurations.
 #

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -11,7 +11,7 @@ falcon_api_enable_no_log: yes
 # Whether or not to enable run_once for API calls.
 # By default, this is enabled.
 #
-falcon_api_enable_run_once: yes
+falcon_sensor_update_policy_run_once: yes
 
 # Whether or not to ignore errors associated with unsupported Falcon Sensor Kernel
 # configurations.

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -11,7 +11,7 @@ falcon_api_enable_no_log: yes
 # Whether or not to enable run_once for API calls.
 # By default, this is enabled.
 #
-falcon_sensor_update_policy_run_once: yes
+falcon_api_auth_run_once: yes
 
 # Whether or not to ignore errors associated with unsupported Falcon Sensor Kernel
 # configurations.
@@ -98,6 +98,11 @@ falcon_sensor_version_decrement: 0
 #   falcon_sensor_update_policy_name: "platform_default"
 #
 falcon_sensor_update_policy_name: ""
+
+# Whether or not to enable run_once for the Sensor update policy API calls.
+# By default, this is enabled.
+#
+falcon_sensor_update_policy_run_once: yes
 
 # Where should the sensor file be downloaded to on Linux and MacOS systems?
 # By default, this will be the temp OS filesystem

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -19,7 +19,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info_linux
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: yes
+      run_once: "{{ falcon_api_enable_run_once }}"
 
 - name: Build Sensor Update Policy Block (MacOS)
   when:
@@ -40,7 +40,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info_mac
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: yes
+      run_once: "{{ falcon_api_enable_run_once }}"
 
 - name: Sensor Update Policy Block
   when:

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -19,7 +19,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info_linux
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: "{{ falcon_api_enable_run_once }}"
+      run_once: "{{ falcon_sensor_update_policy_run_once }}"
 
 - name: Build Sensor Update Policy Block (MacOS)
   when:
@@ -40,7 +40,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info_mac
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: "{{ falcon_api_enable_run_once }}"
+      run_once: "{{ falcon_sensor_update_policy_run_once }}"
 
 - name: Sensor Update Policy Block
   when:

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -13,7 +13,7 @@
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: "{{ falcon_api_enable_run_once }}"
+  run_once: "{{ falcon_api_auth_run_once }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -35,7 +35,7 @@
         Content-Type: application/json
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
-    run_once: "{{ falcon_api_enable_run_once }}"
+    run_once: "{{ falcon_api_auth_run_once }}"
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -13,7 +13,7 @@
       content-type: application/x-www-form-urlencoded
   register: falcon_api_oauth2_token
   no_log: "{{ falcon_api_enable_no_log }}"
-  run_once: yes
+  run_once: "{{ falcon_api_enable_run_once }}"
 
 - name: CrowdStrike Falcon | Auto-discover CrowdStrike Cloud Region
   ansible.builtin.set_fact:
@@ -35,7 +35,7 @@
         Content-Type: application/json
     register: falcon_api_target_cid
     no_log: "{{ falcon_api_enable_no_log }}"
-    run_once: yes
+    run_once: "{{ falcon_api_enable_run_once }}"
 
   - name: CrowdStrike Falcon | Set CID received from API
     ansible.builtin.set_fact:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -17,7 +17,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: "{{ falcon_api_enable_run_once }}"
+      run_once: "{{ falcon_sensor_update_policy_run_once }}"
 
     - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
       ansible.builtin.fail:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -17,7 +17,7 @@
           Content-Type: application/json
       register: falcon_sensor_update_policy_info
       no_log: "{{ falcon_api_enable_no_log }}"
-      run_once: yes
+      run_once: "{{ falcon_api_enable_run_once }}"
 
     - name: "CrowdStrike Falcon | Validate Sensor Update Policy request"
       ansible.builtin.fail:


### PR DESCRIPTION
Closes #319 

This PR introduces the ability to allow a user to skip the `run_once` options on the API calls. Currently, this is enabled with no ways of overriding it. 