### PR TITLE
Add sort|desc to os_version in sensor query

### DIFF
--- a/changelogs/fragments/fix-decrement-sorting.yml
+++ b/changelogs/fragments/fix-decrement-sorting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_install - fix issue with sorting of returned versions when using falcon_sensor_version_decrement (https://github.com/CrowdStrike/ansible_collection_falcon/pull/325)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -100,7 +100,7 @@
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
   ansible.builtin.uri:
-    url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"
+    url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?sort=version|desc&filter={{ falcon_os_query | urlencode }}"
     method: GET
     return_content: true
     headers:

--- a/roles/falcon_install/tasks/win_api.yml
+++ b/roles/falcon_install/tasks/win_api.yml
@@ -40,7 +40,7 @@
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
   ansible.windows.win_uri:
-    url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"
+    url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?sort=version|desc&filter={{ falcon_os_query | urlencode }}"
     method: GET
     return_content: true
     headers:


### PR DESCRIPTION
Fixes #323 

This PR adds sorting to the sensor installer query to ensure we get back the correct ordering in order to use the version decrement correctly.