### PR TITLE
Add arch to kernel compat query + add new json filter for proper subset

### DIFF
--- a/changelogs/fragments/fix-kernel-compat-query.yml
+++ b/changelogs/fragments/fix-kernel-compat-query.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_install - fix kernel compatibility query (https://github.com/CrowdStrike/ansible_collection_falcon/pull/332)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -120,7 +120,7 @@
   block:
     - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
       ansible.builtin.set_fact:
-        falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_facts['kernel'] + '\"' }}"
+        falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_facts['kernel'] + '\"+architecture:\"' + ansible_facts['architecture'] + '\"' }}"
 
     - name: CrowdStrike Falcon | Get list of Supported Kernels
       ansible.builtin.uri:
@@ -139,6 +139,10 @@
         fail_msg: "The kernel version: {{ ansible_facts['kernel'] }} is not supported by the Falcon Sensor!"
       ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
 
+    - name: CrowdStrike Falcon | Filter JSON Response to get Correct Subset
+      ansible.builtin.set_fact:
+        falcon_sensor_update_kernels_list_filtered: "{{ falcon_sensor_update_kernels_list.json.resources | selectattr('distro_version', 'search', ansible_facts['distribution_major_version']) | list }}"
+
     - name: CrowdStrike Falcon | Validate Sensor version is compatible with Kernel
       ansible.builtin.assert:
         that: falcon_sensor_version in falcon_base_package_supported_sensor_versions or
@@ -147,10 +151,10 @@
         fail_msg: "The sensor version: {{ falcon_sensor_version }} is not supported with kernel: {{ ansible_facts['kernel'] }}"
       vars:
         falcon_sensor_version: "{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].version }}"
-        falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].base_package_supported_sensor_versions }}"
-        falcon_ztl_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].ztl_supported_sensor_versions }}"
-        falcon_ztl_module_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list.json.resources[0].ztl_module_supported_sensor_versions }}"
-      when: falcon_sensor_update_kernels_list.json.resources
+        falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].base_package_supported_sensor_versions }}"
+        falcon_ztl_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].ztl_supported_sensor_versions }}"
+        falcon_ztl_module_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].ztl_module_supported_sensor_versions }}"
+      when: falcon_sensor_update_kernels_list_filtered | length > 0
       ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
 
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package


### PR DESCRIPTION
Fixes #331 

This PR addresses an issue with the kernel compat API call results. Results now include architectural differences so we have to account for these with filters. 
> This was accomplished by adding the `architecture: "ansible_facts['architecture']"` filter

Unfortunately, the fql filter to check if some string is in distro_version does not work as intended. As a workaround, I created a new fact that searches for the distro major version in the resources[*].distro_version field.
> This was accomplished by using the selectattr filter: `selectattr('distro_version', 'search', ansible_facts['distribution_major_version'])`

- [x] Test different operating systems (using vm's, not containers)
- [x] Ensure distro_version filter is being used properly