### PR TITLE
Fix downgrade issue with SUSE/zypper

### DIFF
--- a/roles/falcon_install/tasks/install.yml
+++ b/roles/falcon_install/tasks/install.yml
@@ -37,6 +37,7 @@
     deb: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in dpkg_packagers) else omit }}"
     name: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in rpm_packagers) else omit }}"
     allow_downgrade: "{{ falcon_allow_downgrade if (ansible_facts['pkg_mgr'] != 'zypper') else omit }}"
+    oldpackage: "{{ falcon_allow_downgrade if (ansible_facts['pkg_mgr'] == 'zypper') else omit }}"
     state: present
   when:
     - ansible_facts['pkg_mgr'] in linux_packagers

--- a/roles/falcon_install/tasks/install.yml
+++ b/roles/falcon_install/tasks/install.yml
@@ -36,7 +36,7 @@
   ansible.builtin.package:
     deb: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in dpkg_packagers) else omit }}"
     name: "{{ falcon_sensor_pkg if (ansible_facts['pkg_mgr'] in rpm_packagers) else omit }}"
-    allow_downgrade: "{{ falcon_allow_downgrade }}"
+    allow_downgrade: "{{ falcon_allow_downgrade if (ansible_facts['pkg_mgr'] != 'zypper') else omit }}"
     state: present
   when:
     - ansible_facts['pkg_mgr'] in linux_packagers


### PR DESCRIPTION
Fixes #343 

This PR fixes an issue when the zypper package manager module is used, allow_downgrade is not a valid option. Instead, it uses oldpackage to allow downgrading.