### PR TITLE
feat: Add support for Amazon Linux 2023 in Falcon workflows

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -47,6 +47,11 @@ jobs:
             image_arch: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04*
             instance_type: t2.micro
+          - distro: amazon-2023
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: al2023-ami-2023*
+            instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'
             image_arch: x86_64

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -47,6 +47,11 @@ jobs:
             image_arch: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04*
             instance_type: t2.micro
+          - distro: amazon-2023
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: al2023-ami-2023*
+            instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'
             image_arch: x86_64

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -47,6 +47,11 @@ jobs:
             image_arch: x86_64
             image_name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04*
             instance_type: t2.micro
+          - distro: amazon-2023
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: al2023-ami-2023*
+            instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'
             image_arch: x86_64


### PR DESCRIPTION
This commit adds support for Amazon Linux 2023 in the Falcon workflows by including it as a new option in the matrix of supported distros. 