### PR TITLE
fix: Update matrix exclusion and falcon sensor version decrement

### DIFF
--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -86,6 +86,15 @@ jobs:
           - falcon_install
           - falcon_install_policy
           - falcon_install_allow_downgrade
+        exclude:
+          # Exclude until more sensor versions are available
+          - molecule:
+              distro: amazon-2023
+              image_owner: '137112412989'
+              image_arch: x86_64
+              image_name: al2023-ami-2023*
+              instance_type: t2.micro
+            collection_role: falcon_install_allow_downgrade
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/molecule/falcon_install_allow_downgrade/converge.yml
+++ b/molecule/falcon_install_allow_downgrade/converge.yml
@@ -5,7 +5,7 @@
   vars:
     falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
-    falcon_sensor_version_decrement: 2
+    falcon_sensor_version_decrement: 1
     falcon_allow_downgrade: true
   roles:
     - role: crowdstrike.falcon.falcon_install


### PR DESCRIPTION
Due to the recent addition of Amazon 2023 support - there is only one current version of the sensor available, so that was throwing off the policy and downgrade ci.
- Added matrix exclusion for falcon_install_allow_downgrade role on Amazon-2023 until more sensor versions are available.
- Changed falcon_sensor_version_decrement from 2 to 1 in falcon_install_allow_downgrade converge configuration.