### PR TITLE
Skipping role_prefix var naming rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,6 +7,7 @@ enable_list:
 skip_list:
   - '204'
   - 'ignore-errors'
+  - 'var-naming[no-role-prefix]'
 
 warn_list:
   - experimental


### PR DESCRIPTION
This really is not a big deal, plus we can revisit this when we move towards v4.