### PR TITLE
Add amazon linux 2 to ci + stagger schedule

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -1,7 +1,7 @@
 name: "falcon_configure"
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 3 * * *'
   push:
     paths:
       - 'roles/falcon_configure/**'
@@ -51,6 +51,11 @@ jobs:
             image_owner: '137112412989'
             image_arch: x86_64
             image_name: al2023-ami-2023*
+            instance_type: t2.micro
+          - distro: amazon-2
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -1,7 +1,7 @@
 name: "falcon_install"
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 4 * * *'
   push:
     paths:
       - 'roles/falcon_install/**'
@@ -51,6 +51,11 @@ jobs:
             image_owner: '137112412989'
             image_arch: x86_64
             image_name: al2023-ami-2023*
+            instance_type: t2.micro
+          - distro: amazon-2
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -1,7 +1,7 @@
 name: "falcon_uninstall"
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 5 * * *'
   push:
     paths:
       - 'roles/falcon_uninstall/**'
@@ -51,6 +51,11 @@ jobs:
             image_owner: '137112412989'
             image_arch: x86_64
             image_name: al2023-ami-2023*
+            instance_type: t2.micro
+          - distro: amazon-2
+            image_owner: '137112412989'
+            image_arch: x86_64
+            image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
           - distro: sles-15-sp4
             image_owner: '013907871322'

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -1,7 +1,7 @@
 name: "win_falcon_install"
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 7 * * *'
   push:
     paths:
       - 'roles/falcon_install/**'

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -1,7 +1,7 @@
 name: "win_falcon_uninstall"
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 8 * * *'
   push:
     paths:
       - 'roles/falcon_uninstall/**'


### PR DESCRIPTION
Not sure why I never had Amazon Linux 2 in CI, but adding it here.

Also staggering CI scheduled jobs to see if that helps with existing CI errors and to prevent any resource contention.