### PR TITLE
Removed kernel compat due to prevelance of ebpf support

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -147,7 +147,7 @@ jobs:
           command: >-
             molecule --version &&
             ansible --version &&
-            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v
         continue-on-error: true
 
       - name: Ensure instances are destroyed

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -158,7 +158,7 @@ jobs:
           command: >-
             molecule --version &&
             ansible --version &&
-            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v
         continue-on-error: true
 
       - name: Ensure instances are destroyed

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -147,7 +147,7 @@ jobs:
           command: >-
             molecule --version &&
             ansible --version &&
-            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v -e "falcon_skip_kernel_compat_check=yes"
+            molecule --debug test --destroy never -s ${{ matrix.collection_role }} -- -v
         continue-on-error: true
 
       - name: Ensure instances are destroyed

--- a/changelogs/fragments/remove-kernel-compat.yml
+++ b/changelogs/fragments/remove-kernel-compat.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- falcon_install - removing kernel compat check due to prevelance of ebpf (https://github.com/CrowdStrike/ansible_collection_falcon/pull/367)

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -15,7 +15,6 @@ The following variables are currently supported:
 
  * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
  * `falcon_api_auth_run_once` - Whether to enable or disable the run_once option for API auth calls. (bool, default: true)
- * `falcon_skip_kernel_compat_check` - Whether or not to ignore errors associated with unsupported Falcon Sensor/Kernel combination. (bool, default: false)
  * `falcon_allow_downgrade` - Whether or not to allow downgrading the sensor version. (bool, default: false)
  * `falcon_install_method` - The installation method for installing the sensor (string, default: api)
  * `falcon_gpg_key_check` - Whether or not to verify the Falcon sensor Linux based package (bool, default: true)

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -13,14 +13,6 @@ falcon_api_enable_no_log: yes
 #
 falcon_api_auth_run_once: yes
 
-# Whether or not to ignore errors associated with unsupported Falcon Sensor Kernel
-# configurations.
-#
-# By default, this is disabled - which will fail the play when the Falcon Sensor and Kernel
-# are unsupported.
-#
-falcon_skip_kernel_compat_check: no
-
 # Whether or not to allow downgrading the Falcon Sensor.
 falcon_allow_downgrade: no
 

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -114,49 +114,6 @@
     msg: "No Falcon Sensor was found! If passing in falcon_sensor_version, ensure it is correct!"
   when: falcon_api_installer_list.json.resources[0] is not defined
 
-# Block for checking sensor/kernel compatibility
-- name: Sensor Kernel Compatability Block
-  when: ansible_facts['system'] == "Linux"
-  block:
-    - name: CrowdStrike Falcon | Build Sensor Update Kernels API Query
-      ansible.builtin.set_fact:
-        falcon_sensor_update_kernels_query: "{{ 'vendor:\"' + falcon_os_vendor + '\"+release:\"' + ansible_facts['kernel'] + '\"+architecture:\"' + ansible_facts['architecture'] + '\"' }}"
-
-    - name: CrowdStrike Falcon | Get list of Supported Kernels
-      ansible.builtin.uri:
-        url: "https://{{ falcon_cloud }}/policy/combined/sensor-update-kernels/v1?filter={{ falcon_sensor_update_kernels_query | urlencode }}"
-        method: GET
-        return_content: true
-        headers:
-          authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
-          Content-Type: application/json
-      register: falcon_sensor_update_kernels_list
-      no_log: "{{ falcon_api_enable_no_log }}"
-
-    - name: CrowdStrike Falcon | Validate Kernel is Supported
-      ansible.builtin.assert:
-        that: falcon_sensor_update_kernels_list.json.resources
-        fail_msg: "The kernel version: {{ ansible_facts['kernel'] }} is not supported by the Falcon Sensor!"
-      ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
-
-    - name: CrowdStrike Falcon | Filter JSON Response to get Correct Subset
-      ansible.builtin.set_fact:
-        falcon_sensor_update_kernels_list_filtered: "{{ falcon_sensor_update_kernels_list.json.resources | selectattr('distro_version', 'search', ansible_facts['distribution_major_version']) | list }}"
-
-    - name: CrowdStrike Falcon | Validate Sensor version is compatible with Kernel
-      ansible.builtin.assert:
-        that: falcon_sensor_version in falcon_base_package_supported_sensor_versions or
-              falcon_sensor_version in falcon_ztl_supported_sensor_versions or
-              falcon_sensor_version in falcon_ztl_module_supported_sensor_versions
-        fail_msg: "The sensor version: {{ falcon_sensor_version }} is not supported with kernel: {{ ansible_facts['kernel'] }}"
-      vars:
-        falcon_sensor_version: "{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].version }}"
-        falcon_base_package_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].base_package_supported_sensor_versions }}"
-        falcon_ztl_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].ztl_supported_sensor_versions }}"
-        falcon_ztl_module_supported_sensor_versions: "{{ falcon_sensor_update_kernels_list_filtered[0].ztl_module_supported_sensor_versions }}"
-      when: falcon_sensor_update_kernels_list_filtered | length > 0
-      ignore_errors: "{{ falcon_skip_kernel_compat_check }}"
-
 - name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   ansible.builtin.get_url:
     url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].sha256 }}"


### PR DESCRIPTION
Closes #356 

This PR removes the need for the `falcon_skip_kernel_compat_check` kernel compatibility step since the falcon sensor has introduced eBPF support. The reasoning to remove this is as follows:
- None of our other tools provide this capability
- One less API call to be dependent on in terms of reliable information
- Handling edge cases like RHEL 8, where a kernel that is less than the 5.8 but has a compatible ebpf backport would be difficult to track w/o an API to check.

This should be a minor change - even if you are still using the `falcon_skip_kernel_compat_check` variable, it won't be used as there is no call to it within the role.
