### PR TITLE
dest should follow same convention as linux

### DIFF
--- a/changelogs/fragments/url_ability_for_windows.yml
+++ b/changelogs/fragments/url_ability_for_windows.yml
@@ -1,2 +1,5 @@
 minor_changes:
 - falcon_install - add the ability to install from an URL for windows (https://github.com/CrowdStrike/ansible_collection_falcon/pull/363)
+
+bugfixes:
+- falcon_install - use tmp path instead of hardcoding sensor name (https://github.com/CrowdStrike/ansible_collection_falcon/pull/368)

--- a/roles/falcon_install/tasks/win_url.yml
+++ b/roles/falcon_install/tasks/win_url.yml
@@ -2,7 +2,7 @@
 - name: CrowdStrike Falcon | Downloading Installation Package from URL (Windows)
   ansible.windows.win_get_url:
     url: "{{ falcon_download_url }}"
-    dest: "{{ falcon_windows_tmp_dir }}\\falcon-sensor.exe"
+    dest: "{{ falcon_windows_tmp_dir.path }}"
     url_username: "{{ falcon_download_url_username | default(omit) }}"
     url_password: "{{ falcon_download_url_password | default(omit) }}"
   when:


### PR DESCRIPTION
The temp file path will be where the file is downloaded to. This does not impact the name. 

If you have a url: `http://example.com/path/to/sensor.exe` 

Then it will be `falcon_windows_tmp_dir.path/sensor.exe` which might look something like this: `C:\\Windows\\Temp\\ansible.1jm0zgju.podfalcon\\sensor.exe`