### PR TITLE
Bump 3.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,26 @@ Ansible CrowdStrike Falcon Collection Release Notes
 .. contents:: Topics
 
 
+v3.3.0
+======
+
+Release Summary
+---------------
+
+| Release Date: 2023-08-04
+| `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.3.0>`__
+
+
+Minor Changes
+-------------
+
+- evenstream-eda - Introducing new EvenStream EDA plugin (https://github.com/CrowdStrike/ansible_collection_falcon/pull/322)
+
+Bugfixes
+--------
+
+- falcon_install - Fix Windows destination URL (https://github.com/CrowdStrike/ansible_collection_falcon/pull/375)
+
 v3.2.36
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -276,3 +276,19 @@ releases:
     - remove-kernel-compat.yml
     - url_ability_for_windows.yml
     release_date: '2023-07-28'
+  3.3.0:
+    changes:
+      bugfixes:
+      - falcon_install - Fix Windows destination URL (https://github.com/CrowdStrike/ansible_collection_falcon/pull/375)
+      minor_changes:
+      - evenstream-eda - Introducing new EvenStream EDA plugin (https://github.com/CrowdStrike/ansible_collection_falcon/pull/322)
+      release_summary: '| Release Date: 2023-08-04
+
+        | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.3.0>`__
+
+        '
+    fragments:
+    - 3.3.0.yml
+    - eda.yml
+    - fix-windows-dest-url.yml
+    release_date: '2023-08-04'

--- a/changelogs/fragments/3.3.0.yml
+++ b/changelogs/fragments/3.3.0.yml
@@ -1,3 +1,0 @@
-release_summary: |
-  | Release Date: 2023-08-04
-  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.3.0>`__

--- a/changelogs/fragments/3.3.0.yml
+++ b/changelogs/fragments/3.3.0.yml
@@ -1,0 +1,3 @@
+release_summary: |
+  | Release Date: 2023-08-04
+  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/3.3.0>`__

--- a/changelogs/fragments/eda.yml
+++ b/changelogs/fragments/eda.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - evenstream-eda - Introducing new EvenStream EDA plugin (https://github.com/CrowdStrike/ansible_collection_falcon/pull/322)

--- a/changelogs/fragments/fix-windows-dest-url.yml
+++ b/changelogs/fragments/fix-windows-dest-url.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - falcon_install - Fix Windows destination URL (https://github.com/CrowdStrike/ansible_collection_falcon/pull/375)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.36
+version: 3.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
This release bumps to 3.3.0 due to the addition of the EDA event_source plugin.