### PR TITLE
Host hide module + doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Tested with the Ansible Core >= 2.12.0 versions, and the current development ver
 
 Name | Description
 --- | ---
-[crowdstrike.falcon.falconctl](https://crowdstrike.github.io/ansible_collection_falcon/falconctl_module.html#ansible-collections-crowdstrike-falcon-falconctl-module)|Configure CrowdStrike Falcon Sensor
-[crowdstrike.falcon.falconctl_info](https://crowdstrike.github.io/ansible_collection_falcon/falconctl_info_module.html#ansible-collections-crowdstrike-falcon-falconctl-info-module)|Get Values Associated with Falcon Sensor
+[crowdstrike.falcon.falconctl](https://crowdstrike.github.io/ansible_collection_falcon/falconctl_module.html#ansible-collections-crowdstrike-falcon-falconctl-module)|Configure CrowdStrike Falcon Sensor (Linux)
+[crowdstrike.falcon.falconctl_info](https://crowdstrike.github.io/ansible_collection_falcon/falconctl_info_module.html#ansible-collections-crowdstrike-falcon-falconctl-info-module)|Get Values Associated with Falcon Sensor (Linux)
 [crowdstrike.falcon.auth](https://crowdstrike.github.io/ansible_collection_falcon/auth.html#ansible-collections-crowdstrike-falcon-auth-module)|Manage Authentication with Falcon API
 [crowdstrike.falcon.cid_info](https://crowdstrike.github.io/ansible_collection_falcon/cid_info.html#ansible-collections-crowdstrike-falcon-cid-info-module)|Get CID with checksum
+[crowdstrike.falcon.host_hide](https://crowdstrike.github.io/ansible_collection_falcon/host_hide.html#ansible-collections-crowdstrike-falcon-host-hide-module)|Hide/Unhide hosts from the Falcon console
 [crowdstrike.falcon.sensor_download](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download.html#ansible-collections-crowdstrike-falcon-sensor-download-module)|Download Falcon Sensor Installer
 [crowdstrike.falcon.sensor_download_info](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_info.html#ansible-collections-crowdstrike-falcon-sensor-download-info-module)|Get information about Falcon Sensor Installers
 [crowdstrike.falcon.sensor_update_policy_info](https://crowdstrike.github.io/ansible_collection_falcon/sensor_update_policy_info.html#ansible-collections-crowdstrike-falcon-sensor-update-policy-info-module)|Get information about Falcon Update Sensor Policies

--- a/plugins/doc_fragments/credentials.py
+++ b/plugins/doc_fragments/credentials.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017,  Ansible Project
+# Copyright: (c) 2023, CrowdStrike Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/doc_fragments/info.py
+++ b/plugins/doc_fragments/info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017,  Ansible Project
+# Copyright: (c) 2023, CrowdStrike Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -53,7 +53,6 @@ author:
 EXAMPLES = r"""
 - name: Hide hosts from the Falcon console
   crowdstrike.falcon.host_hide:
-    action: hide
     host_ids: "12345678901234567890"
 
 - name: Unhide hosts from the Falcon console

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -81,14 +81,17 @@ failed_hosts:
       description:
         - The host ID that failed to be hidden or unhidden.
       type: str
+      returned: when a host ID fails
     code:
       description:
         - The error code returned by the API.
       type: int
+      returned: when a host ID fails
     message:
       description:
         - The error message returned by the API.
       type: str
+      returned: when a host ID fails
 """
 
 import traceback

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -1,0 +1,217 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: host_hide
+
+short_description: Hide/Unhide hosts from the Falcon console
+
+version_added: "4.0.0"
+
+description:
+  - Manages the visibility of hosts in the Falcon console.
+  - To prevent unnecessary detections from an inactive or a duplicate host,
+    you can opt to hide the host from the console. This action does not uninstall or
+    deactivate the sensor. Detection reporting resumes after a host is unhidden.
+  - The module will return a list of successfull and failed hosts IDs for the action performed.
+
+options:
+  action:
+    description:
+      - The type of action to perform on the host(s).
+    type: str
+    default: hide
+    choices:
+      - hide
+      - unhide
+  host_ids:
+    description:
+      - A list of host IDs to perform the action on.
+    type: list
+    elements: str
+    required: true
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+requirements:
+  - Hosts [B(WRITE)] API scope
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Hide hosts from the Falcon console
+  crowdstrike.falcon.host_hide:
+    action: hide
+    host_ids: "12345678901234567890"
+
+- name: Unhide hosts from the Falcon console
+  crowdstrike.falcon.host_hide:
+    action: unhide
+    host_ids:
+      - "12345678901234567890"
+      - "09876543210987654321"
+"""
+
+RETURN = r"""
+hosts:
+  description:
+    - A list of host IDs that were successfully hidden or unhidden.
+  type: list
+  returned: always
+  elements: str
+failed_hosts:
+  description:
+    - A list of dictionaries containing host IDs that failed to be hidden or unhidden.
+  type: list
+  returned: always
+  elements: dict
+  contains:
+    id:
+      description:
+        - The host ID that failed to be hidden or unhidden.
+      type: str
+    code:
+      description:
+        - The error code returned by the API.
+      type: int
+    message:
+      description:
+        - The error message returned by the API.
+      type: str
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import Hosts
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+HOSTS_ARGS = dict(
+    action=dict(
+        type="str",
+        default="hide",
+        choices=["hide", "unhide"],
+    ),
+    host_ids=dict(type="list", elements="str", required=True),
+)
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+
+    args.update(HOSTS_ARGS)
+
+    return args
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+
+    action = module.params["action"]
+    host_ids = module.params["host_ids"]
+
+    # Setup the return values
+    result = dict(
+        changed=False,
+        hosts=[],
+        failed_hosts=[],
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    falcon = authenticate(module, Hosts)
+
+    action_name = "hide_host" if action == "hide" else "unhide_host"
+
+    query_result = falcon.perform_action(action_name=action_name, ids=host_ids)
+
+    # The API returns both successful and failed hosts in the same response. This
+    # means we need to handle errors differently than we normally would.
+    good = query_result["body"]["resources"]
+    bad = query_result["body"]["errors"]
+
+    # If we get nothing back, handle the error
+    if not good and not bad:
+        handle_return_errors(module, falcon, query_result)
+
+    # Create a mapping for passed-in host IDs to easily manage their states
+    host_mapping = {host_id: "" for host_id in host_ids}
+
+    # For hosts in 'good', add the ID to the hosts list
+    if good:
+        result["changed"] = True
+        for host in good:
+            host_mapping[host["id"]] = host["id"]
+
+    # For hosts in 'bad', set message based on status code
+    if bad:
+        for host in bad:
+            message = host["message"]
+            for host_id in host_mapping.keys():
+                if host_id in message:
+                    if host["code"] == 409:  # Host already in desired state
+                        host_mapping[host_id] = host_id
+                    else:
+                        result["failed_hosts"].append(
+                            {
+                                "id": host_id,
+                                "code": host["code"],
+                                "message": host["message"],
+                            }
+                        )
+
+    # Add the hosts to the result
+    result["hosts"] = [value for value in host_mapping.values() if value]
+
+    # If no good hosts, then fail the module
+    if not result["hosts"]:
+        module.fail_json(
+            msg=f"All host(s) failed to {action}. Check failed_hosts for details.",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -21,41 +21,42 @@ future.
 
 ### API Specific Variables
 
-- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: `null`)
-- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: `null`)
-- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `us-1`)
+- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: ***null***)
+- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: ***null***)
+- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: ***us-1***)
   - choices:
-    - `us-1` -> api.crowdstrike.com
-    - `us-2` -> api.us-2.crowdstrike.com
-    - `us-gov-1` -> api.laggar.gcw.crowdstrike.com
-    - `eu-1` -> api.eu-1.crowdstrike.com
-- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: `true`)
+    - **us-1** -> api.crowdstrike.com
+    - **us-2** -> api.us-2.crowdstrike.com
+    - **us-gov-1** -> api.laggar.gcw.crowdstrike.com
+    - **eu-1** -> api.eu-1.crowdstrike.com
+- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: ***true***)
 
 ### Common Variables
 
-- `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: null)
+- `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: ***null***)
 
 ### Windows Specific Variables
 
-- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
-- `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: `SYSTEM`)
+- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
+- `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: ***SYSTEM***)
 
 ### Falconctl Variables (Linux Only)
 
 > This role uses the [crowdstrike.falcon.falconctl](../../plugins/modules/falconctl.py) Ansible Module to configure the Falcon Sensor on Linux.
 
-- `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
-- `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: null)
-- `falcon_provisioning_token` - Falcon Installation Token (string, default: null)
-- `falcon_apd` - Enable/Disable the Falcon Proxy. **To enable proxy, set as:** `false|no` (string, default: null)
-- `falcon_aph` - Falcon Proxy host (by FQDN or IP) (string, default: null)
-- `falcon_app` - Falcon Proxy port (string, default: null)
-- `falcon_trace` - Configure additional traces for debugging (string, default: null)
-- `falcon_feature` - Configures additional features to the sensor (list, default: null)
-- `falcon_message_log` - Enable/Disable message logs (string, default: null)
-- `falcon_billing` - Configure Falcon sensor with Pay-As-You-Go billing (string, default: null)
-- `falcon_tags` - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts (string, default: null)
-- `falcon_backend` - The backend to use for the Falcon Sensor `[auto|bpf|kernel]` (string, default: null)
+- `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: ***true***)
+- `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: ***null***)
+- `falcon_provisioning_token` - Falcon Installation Token (string, default: ***null***)
+- `falcon_apd` - Enable/Disable the Falcon Proxy (string, default: ***null***)
+  > To enable proxy, set as: ***false***
+- `falcon_aph` - Falcon Proxy host (by FQDN or IP) (string, default: ***null***)
+- `falcon_app` - Falcon Proxy port (string, default: ***null***)
+- `falcon_trace` - Configure additional traces for debugging (string, default: ***null***)
+- `falcon_feature` - Configures additional features to the sensor (list, default: ***null***)
+- `falcon_message_log` - Enable/Disable message logs (string, default: ***null***)
+- `falcon_billing` - Configure Falcon sensor with Pay-As-You-Go billing (string, default: ***null***)
+- `falcon_tags` - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts (string, default: ***null***)
+- `falcon_backend` - The backend to use for the Falcon Sensor `[auto|bpf|kernel]` (string, default: ***null***)
 
 ----------
 

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -1,36 +1,63 @@
-falcon_configure
-=========
+# crowdstrike.falcon.falcon_configure
 
-This role configures the CrowdStrike Falcon Sensor.
+This role configures the CrowdStrike Falcon Sensor. For Linux, this role requires the Falcon
+sensor to be installed prior to running this role.
 
-Requirements
-------------
+## Limitations
 
-Ansible 2.11 or higher
+This role is focused mainly on configuring the Falcon Sensor on Linux and MacOS. Windows is supported, but not as
+much functionality is currently available. The main difference is because a lot of the configuration options can
+be set during the installation of the sensor on Windows. We do plan to add more functionality to this role in the
+future.
 
-Role Variables
---------------
+## Requirements
 
- * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
- * `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
- * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `api.crowdstrike.com`)
- * `falcon_cloud_autodiscover` - Auto-discover CrowdStrike API Cloud region (bool, default: true)
- * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
- * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)
- * `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: null)
- * `falcon_provisioning_token` - Falcon Installation Token (string, default: null)
- * `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: null)
- * `falcon_apd` - Enable/Disable the Falcon Proxy. **To enable proxy, set as:** `false|no` (string, default: null)
- * `falcon_aph` - Falcon Proxy host (by FQDN or IP) (string, default: null)
- * `falcon_app` - Falcon Proxy port (string, default: null)
- * `falcon_trace` - Configure additional traces for debugging (string, default: null)
- * `falcon_feature` - Configures additional features to the sensor (list, default: null)
- * `falcon_message_log` - Enable/Disable message logs (string, default: null)
- * `falcon_billing` - Configure Falcon sensor with Pay-As-You-Go billing (string, default: null)
- * `falcon_tags` - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts (string, default: null)
- * `falcon_backend` - The backend to use for the Falcon Sensor `[auto|bpf|kernel]` (string, default: null)
- * `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
- * `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: `SYSTEM`)
+- Ansible 2.12 or higher
+- FalconPy 1.3.0 or higher on Ansible control node
+
+> As of version 4.0.0, this role takes full advantage of the FalconPy SDK for interacting with the CrowdStrike API.
+
+## Role Variables
+
+### API Specific Variables
+
+- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: `null`)
+- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: `null`)
+- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `us-1`)
+  - choices:
+    - `us-1` -> api.crowdstrike.com
+    - `us-2` -> api.us-2.crowdstrike.com
+    - `us-gov-1` -> api.laggar.gcw.crowdstrike.com
+    - `eu-1` -> api.eu-1.crowdstrike.com
+- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: `true`)
+
+### Common Variables
+
+- `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: null)
+
+### Windows Specific Variables
+
+- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
+- `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: `SYSTEM`)
+
+### Falconctl Variables (Linux Only)
+
+> This role uses the [crowdstrike.falcon.falconctl](../../plugins/modules/falconctl.py) Ansible Module to configure the Falcon Sensor on Linux.
+
+- `falcon_option_set` - Set True|yes to set options, False|no to delete. *See note below (bool, default: true)
+- `falcon_cid` - Your Falcon Customer ID (CID) if not using API creds (string, default: null)
+- `falcon_provisioning_token` - Falcon Installation Token (string, default: null)
+- `falcon_apd` - Enable/Disable the Falcon Proxy. **To enable proxy, set as:** `false|no` (string, default: null)
+- `falcon_aph` - Falcon Proxy host (by FQDN or IP) (string, default: null)
+- `falcon_app` - Falcon Proxy port (string, default: null)
+- `falcon_trace` - Configure additional traces for debugging (string, default: null)
+- `falcon_feature` - Configures additional features to the sensor (list, default: null)
+- `falcon_message_log` - Enable/Disable message logs (string, default: null)
+- `falcon_billing` - Configure Falcon sensor with Pay-As-You-Go billing (string, default: null)
+- `falcon_tags` - Sensor grouping tags are optional, user-defined identifiers you can use to group and filter hosts (string, default: null)
+- `falcon_backend` - The backend to use for the Falcon Sensor `[auto|bpf|kernel]` (string, default: null)
+
+----------
 
 > :warning: **Warning:** **_Not all options can be set and deleted._**
 >
@@ -51,25 +78,24 @@ Role Variables
 | falcon_tags               | S/D   |
 | falcon_backend            | S/D   |
 
-Falcon API Permissions
-----------------------
+## Falcon API Permissions
 
 API clients are granted one or more API scopes. Scopes allow access to specific CrowdStrike APIs and describe the actions that an API client can perform.
 
 Ensure the following API scopes are enabled (***if applicable***) for this role:
-* When using API credentials `falcon_client_id` and `falcon_client_secret`
-  * **Sensor Download** [read]
 
-Dependencies
-------------
+- When using API credentials `falcon_client_id` and `falcon_client_secret`
+  - **Sensor Download** [read]
+
+## Dependencies
 
 - Privilege escalation (sudo) is required for this role to function properly.
 - Falcon Sensor must be installed
 
-Example Playbook
-----------------
+## Example Playbooks
 
 How to set the Falcon Customer ID (CID) when CID is known:
+
 ```yaml
 - hosts: all
   roles:
@@ -79,6 +105,7 @@ How to set the Falcon Customer ID (CID) when CID is known:
 ```
 
 How to set the Falcon Customer ID (CID) using API creds:
+
 ```yaml
 - hosts: all
   roles:
@@ -89,6 +116,7 @@ How to set the Falcon Customer ID (CID) using API creds:
 ```
 
 How to set the Falcon Customer ID (CID) w/ provisioning token:
+
 ```yaml
 - hosts: all
   roles:
@@ -99,6 +127,7 @@ How to set the Falcon Customer ID (CID) w/ provisioning token:
 ```
 
 How to configure the Falcon Sensor Proxy:
+
 ```yaml
 - hosts: all
   roles:
@@ -110,6 +139,7 @@ How to configure the Falcon Sensor Proxy:
 ```
 
 This example shows how to set some of the other options:
+
 ```yaml
 - hosts: all
   roles:
@@ -121,6 +151,7 @@ This example shows how to set some of the other options:
 ```
 
 Examples of deleting options:
+
 ```yaml
 - hosts: all
   roles:
@@ -132,6 +163,7 @@ Examples of deleting options:
 ```
 
 Delete Agent ID to prep Master Image:
+
 ```yaml
 - hosts: all
   roles:
@@ -141,12 +173,10 @@ Delete Agent ID to prep Master Image:
       falcon_remove_aid: yes
 ```
 
-License
--------
+## License
 
 [License](https://github.com/crowdstrike/ansible_collection_falcon/blob/main/LICENSE)
 
-Author Information
-------------------
+## Author Information
 
 CrowdStrike Solution Architects

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -39,6 +39,7 @@
   ansible.builtin.stat:
     path: "/Applications/Falcon.app/Contents/Resources/falconctl"
   register: falconctl_mac
+  when: ansible_facts['distribution'] == "MacOSX"
 
 - name: MacOSX Block
   when:

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -14,71 +14,62 @@ the sensor from a local file or remote URL.
 
 The following variables are currently supported:
 
-**Installation Method**
+### Installation Method
 
-- `falcon_install_method` - The installation method for installing the sensor (string, default: `api`)
+- `falcon_install_method` - The installation method for installing the sensor (string, default: ***api***)
   - choices:
-    - `api` - Install the sensor using the CrowdStrike API
-    - `file` - Install the sensor using a local file
-    - `url` - Install the sensor using a remote URL
+    - **api** - Install the sensor using the CrowdStrike API
+    - **file** - Install the sensor using a local file
+    - **url** - Install the sensor using a remote URL
 
-**Common Installation Variables**
+### Common Installation Variables
 
-- `falcon_allow_downgrade` - Whether or not to allow downgrading the sensor version (bool, default: false)
-- `falcon_gpg_key_check` - Whether or not to verify the Falcon sensor Linux based package (bool, default: true)
-- `falcon_cid` - Specify CrowdStrike Customer ID with Checksum (string, default: `null`)
+- `falcon_allow_downgrade` - Whether or not to allow downgrading the sensor version (bool, default: ***false***)
+- `falcon_gpg_key_check` - Whether or not to verify the Falcon sensor Linux based package (bool, default: ***true***)
+- `falcon_cid` - Specify CrowdStrike Customer ID with Checksum (string, default: ***null***)
   - :warning: When `falcon_install_method` is set to **api**, this value will be fetched by the API unless specified.
-- `falcon_install_tmp_dir` - Temporary Linux and MacOS installation directory for the Falson Sensor (string, default: `/tmp/`)
-- `falcon_retries` - Number of attempts to download the sensor (int, default: 3)
-- `falcon_delay` - Number of seconds before trying another download attempt (int, default: 3)
+- `falcon_install_tmp_dir` - Temporary Linux and MacOS installation directory for the Falson Sensor (string, default: ***/tmp***)
+- `falcon_retries` - Number of attempts to download the sensor (int, default: ***3***)
+- `falcon_delay` - Number of seconds before trying another download attempt (int, default: ***3***)
 
-----------
+### API Installation Variables
 
-**API Installation Variables**
-
-- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: `null`)
-- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: `null`)
-- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `us-1`)
+- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: ***null***)
+- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: ***null***)
+- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: ***us-1***)
   - choices:
-    - `us-1` -> api.crowdstrike.com
-    - `us-2` -> api.us-2.crowdstrike.com
-    - `us-gov-1` -> api.laggar.gcw.crowdstrike.com
-    - `eu-1` -> api.eu-1.crowdstrike.com
-- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: `true`)
-- `falcon_api_sensor_download_path` - Local directory path to download the sensor to (string, default: `null`)
-- `falcon_api_sensor_download_filename` - The name to save the sensor file as (string, default: `null`)
-- `falcon_api_sensor_download_cleanup` - Whether or not to delete the downloaded sensor after transfer to remote host (bool, default: `true`)
-- `falcon_sensor_version` - Sensor version to install (string, default: `null`)
-- `falcon_sensor_version_decrement` - Sensor N-x version to install (int, default: 0 [latest])
-- `falcon_sensor_update_policy_name` - Sensor update policy used to control sensor version (string, default: `null`)
+    - **us-1** -> api.crowdstrike.com
+    - **us-2** -> api.us-2.crowdstrike.com
+    - **us-gov-1** -> api.laggar.gcw.crowdstrike.com
+    - **eu-1** -> api.eu-1.crowdstrike.com
+- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: ***true***)
+- `falcon_api_sensor_download_path` - Local directory path to download the sensor to (string, default: ***null***)
+- `falcon_api_sensor_download_filename` - The name to save the sensor file as (string, default: ***null***)
+- `falcon_api_sensor_download_cleanup` - Whether or not to delete the downloaded sensor after transfer to remote host (bool, default: ***true***)
+- `falcon_sensor_version` - Sensor version to install (string, default: ***null***)
+- `falcon_sensor_version_decrement` - Sensor N-x version to install (int, default: ***0*** [latest])
+- `falcon_sensor_update_policy_name` - Sensor update policy used to control sensor version (string, default: ***null***)
 
-----------
+### File Installation Variables
 
-**File Installation Variables**
+- `falcon_localfile_path` - Absolute path to local falcon sensor package (string, default: ***null***)
+- `falcon_localfile_cleanup` - Allow removing the local file after install (bool, default: ***false***)
 
-- `falcon_localfile_path` - Absolute path to local falcon sensor package (string, default: `null`)
-- `falcon_localfile_cleanup` - Allow removing the local file after install (bool, default: false)
+### URL Installation Variables
 
-----------
+- `falcon_download_url` - URL for downloading the sensor (string, default: ***null***)
+- `falcon_download_url_username` - username for downloading the sensor (string, default: ***null***)
+- `falcon_download_url_password` - password for downloading the sensor (string, default: ***null***)
 
-**URL Installation Variables**
+### Windows Specific Variables
 
-- `falcon_download_url` - URL for downloading the sensor (string, default: `null`)
-- `falcon_download_url_username` - username for downloading the sensor (string, default: `null`)
-- `falcon_download_url_password` - password for downloading the sensor (string, default: `null`)
-
-----------
-
-
-**Windows Specific Variables**
-
-- `falcon_windows_install_retries` - Number of times to retry sensor install on windows (int, default: 10)
-- `falcon_windows_install_delay` - Number of seconds to wait to retry sensor install on windows in the event of a failure (int, default: 120)
-- `falcon_windows_tmp_dir` - Temporary Windows installation directory for the Falson Sensor (string, default: `%SYSTEMROOT%\\Temp`)
-- `falcon_windows_install_args` - Additional Windows install arguments (string, default: `/norestart`)
-- `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: `/norestart`)
-- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
-- `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: `SYSTEM`)
+- `falcon_windows_install_retries` - Number of times to retry sensor install on windows (int, default: ***10***)
+- `falcon_windows_install_delay` - Number of seconds to wait to retry sensor install on windows in the event of a failure (int, default: ***120***)
+- `falcon_windows_tmp_dir` - Temporary Windows installation directory for the Falson Sensor (string, default: ***%SYSTEMROOT%\\Temp***)
+- `falcon_windows_install_args` - Additional Windows install arguments (string, default: ***/norestart***)
+- `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: ***/norestart***)
+- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
+- `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: ***SYSTEM***)
 
 See [defaults/main.yml](defaults/main.yml) for more details on these variables.
 

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -1,13 +1,14 @@
-# falcon_install
+# crowdstrike.falcon.falcon_install
 
-This role installs the CrowdStrike Falcon Sensor. As of version 4.0.0, this role takes full advantage
-of the FalconPy SDK for installing the sensor via the CrowdStrike API. This role also supports installing
+This role installs the CrowdStrike Falcon Sensor. This role also supports installing
 the sensor from a local file or remote URL.
 
 ## Requirements
 
 - Ansible 2.12 or higher
 - FalconPy 1.3.0 or higher on Ansible control node
+
+> As of version 4.0.0, this role takes full advantage of the FalconPy SDK for interacting with the CrowdStrike API.
 
 ## Role Variables
 

--- a/roles/falcon_uninstall/README.md
+++ b/roles/falcon_uninstall/README.md
@@ -13,22 +13,22 @@ This role uninstalls the CrowdStrike Falcon Sensor.
 
 ### API Specific Variables
 
-- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: `null`)
-- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: `null`)
-- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `us-1`)
+- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: ***null***)
+- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: ***null***)
+- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: ***us-1***)
   - choices:
-    - `us-1` -> api.crowdstrike.com
-    - `us-2` -> api.us-2.crowdstrike.com
-    - `us-gov-1` -> api.laggar.gcw.crowdstrike.com
-    - `eu-1` -> api.eu-1.crowdstrike.com
-- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: `true`)
+    - **us-1** -> api.crowdstrike.com
+    - **us-2** -> api.us-2.crowdstrike.com
+    - **us-gov-1** -> api.laggar.gcw.crowdstrike.com
+    - **eu-1** -> api.eu-1.crowdstrike.com
+- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: ***true***)
 - `falcon_remove_host` - Whether to hide/remove the host from the CrowdStrike console (bool, default: false)
 
 ### Windows Specific Variables
 
-- `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: `/norestart`)
-- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
-- `falcon_windows_become_user` - The privileged user to uninstall the sensor on Windows (string, default: `SYSTEM`)
+- `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: ***/norestart***)
+- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
+- `falcon_windows_become_user` - The privileged user to uninstall the sensor on Windows (string, default: ***SYSTEM***)
 
 See [defaults/main.yml](defaults/main.yml) for more details on these variables.
 

--- a/roles/falcon_uninstall/README.md
+++ b/roles/falcon_uninstall/README.md
@@ -1,48 +1,52 @@
-Uninstall
-=========
+# crowdstrike.falcon.falcon_uninstall
 
 This role uninstalls the CrowdStrike Falcon Sensor.
 
-Requirements
-------------
+## Requirements
 
-Ansible 2.11 or higher
+- Ansible 2.12 or higher
+- FalconPy 1.3.0 or higher on Ansible control node
 
-Role Variables
---------------
+> As of version 4.0.0, this role takes full advantage of the FalconPy SDK for interacting with the CrowdStrike API.
 
-The following variables are currently supported:
+## Role Variables
 
- * `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls. (bool, default: true)
- * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `api.crowdstrike.com`)
- * `falcon_cloud_autodiscover` - Auto-discover CrowdStrike API Cloud region (bool, default: true)
- * `falcon_client_id` - CrowdStrike API OAUTH Client ID (string, default: null)
- * `falcon_client_secret` - CrowdStrike API OAUTH Client Secret (string, default: null)
- * `falcon_remove_host` - Whether to hide/remove the host from the CrowdStrike console (bool, default: false)
- * `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: `/norestart`)
- * `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
- * `falcon_windows_become_user` - The privileged user to uninstall the sensor on Windows (string, default: `SYSTEM`)
+### API Specific Variables
+
+- `falcon_client_id` - CrowdStrike OAUTH Client ID (string, default: `null`)
+- `falcon_client_secret` - CrowdStrike OAUTH Client Secret (string, default: `null`)
+- `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor (string, default: `us-1`)
+  - choices:
+    - `us-1` -> api.crowdstrike.com
+    - `us-2` -> api.us-2.crowdstrike.com
+    - `us-gov-1` -> api.laggar.gcw.crowdstrike.com
+    - `eu-1` -> api.eu-1.crowdstrike.com
+- `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: `true`)
+- `falcon_remove_host` - Whether to hide/remove the host from the CrowdStrike console (bool, default: false)
+
+### Windows Specific Variables
+
+- `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: `/norestart`)
+- `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: `runas`)
+- `falcon_windows_become_user` - The privileged user to uninstall the sensor on Windows (string, default: `SYSTEM`)
 
 See [defaults/main.yml](defaults/main.yml) for more details on these variables.
 
-Falcon API Permissions
-----------------------
+## Falcon API Permissions
 
 API clients are granted one or more API scopes. Scopes allow access to specific CrowdStrike APIs and describe the actions that an API client can perform.
 
-Ensure the following API scopes are enabled (***if applicable***) for this role:
+Ensure the following API scopes are enabled (**if applicable**) for this role:
 
-* When using API credentials `falcon_client_id` and `falcon_client_secret`
-  * To hide/remove the host from the CrowdStrike console:
-    * **Host** [write]****
+- When using API credentials `falcon_client_id` and `falcon_client_secret`
+  - To hide/remove the host from the CrowdStrike console:
+    - **Host** [write]
 
-Dependencies
-------------
+## Dependencies
 
 Privilege escalation (sudo) is required for this role to function properly.
 
-Example Playbooks
-----------------
+## Example Playbooks
 
 This example uninstalls the Falcon Sensor:
 
@@ -53,12 +57,35 @@ This example uninstalls the Falcon Sensor:
   - role: crowdstrike.falcon.falcon_uninstall
 ```
 
-License
--------
+This example uninstalls the Falcon Sensor and hides/removes the host from the CrowdStrike console:
+
+```yaml
+---
+- hosts: all
+  roles:
+  - role: crowdstrike.falcon.falcon_uninstall
+    vars:
+      falcon_client_id: <Falcon_UI_OAUTH_client_id>
+      falcon_client_secret: <Falcon_UI_OAUTH_client_secret>
+      falcon_cloud: us-2
+      falcon_remove_host: true
+```
+
+This example uses a maintenance token to uninstall a Falcon Sensor on Windows:
+
+```yaml
+---
+- hosts: all
+  roles:
+  - role: crowdstrike.falcon.falcon_uninstall
+    vars:
+      falcon_windows_uninstall_args: "/norestart MAINTENANCE_TOKEN=<Falcon_Maintenance_Token>"
+```
+
+## License
 
 [License](https://github.com/crowdstrike/ansible_collection_falcon/blob/main/LICENSE)
 
-Author Information
-------------------
+## Author Information
 
 CrowdStrike Solution Architects

--- a/roles/falcon_uninstall/defaults/main.yml
+++ b/roles/falcon_uninstall/defaults/main.yml
@@ -16,11 +16,6 @@ falcon_api_enable_no_log: yes
 #
 falcon_cloud: "api.crowdstrike.com"
 
-# Auto-discover the CrowdStrike Cloud API Region. When disabled,
-# 'falcon_cloud' should be changed to the appropriate cloud region.
-#
-falcon_cloud_autodiscover: true
-
 # 'Client ID' and 'Client Secret' for authentication against the CrowdStrike
 # API. If unknown, get it from the CrowdStrike support portal:
 #

--- a/roles/falcon_uninstall/tasks/hide_host.yml
+++ b/roles/falcon_uninstall/tasks/hide_host.yml
@@ -1,9 +1,9 @@
 ---
 # This playbook will hide the host from the falcon console
-- name: CrowdStrike Falcon | Remove/Hide Host from Console (Linux)
+- name: CrowdStrike Falcon | Remove/Hide Host from Console
   crowdstrike.falcon.host_hide:
     auth: "{{ falcon.auth }}"
-    action: hide
-    host_ids:
+    hidden: yes
+    hosts:
       - "{{ falcon_uninstall_remove_aid }}"
   delegate_to: localhost

--- a/roles/falcon_uninstall/tasks/hide_host.yml
+++ b/roles/falcon_uninstall/tasks/hide_host.yml
@@ -1,32 +1,9 @@
 ---
 # This playbook will hide the host from the falcon console
-- name: "CrowdStrike Falcon | Remove/Hide Host from Console (Linux)"
-  ansible.builtin.uri:
-    url: "https://{{ falcon_cloud }}/devices/entities/devices-actions/v2?action_name=hide_host"
-    method: POST
-    body_format: json
-    body:
-      ids:
-        - "{{ falcon_uninstall_remove_aid }}"
-    return_content: true
-    headers:
-      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
-      Content-Type: application/json
-    status_code: 202
-  no_log: "{{ falcon_api_enable_no_log }}"
-  when: ansible_facts['os_family'] != "Windows"
-
-- name: "CrowdStrike Falcon | Remove/Hide Host from Console (Windows)"
-  ansible.windows.win_uri:
-    url: "https://{{ falcon_cloud }}/devices/entities/devices-actions/v2?action_name=hide_host"
-    method: POST
-    body:
-      ids:
-        - "{{ falcon_uninstall_remove_aid }}"
-    return_content: true
-    headers:
-      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
-      Content-Type: application/json
-    status_code: 202
-  no_log: "{{ falcon_api_enable_no_log }}"
-  when: ansible_facts['os_family'] == "Windows"
+- name: CrowdStrike Falcon | Remove/Hide Host from Console (Linux)
+  crowdstrike.falcon.host_hide:
+    auth: "{{ falcon.auth }}"
+    action: hide
+    host_ids:
+      - "{{ falcon_uninstall_remove_aid }}"
+  delegate_to: localhost

--- a/roles/falcon_uninstall/tasks/main.yml
+++ b/roles/falcon_uninstall/tasks/main.yml
@@ -11,12 +11,12 @@
   block:
     - ansible.builtin.include_role:
         name: falcon_install
-        tasks_from: "{{ 'win_auth.yml' if ansible_facts['os_family'] == 'Windows' else 'auth.yml' }}"
+        tasks_from: auth
       # noqa name[missing]
 
 - name: Remove/Hide Host pretasks
   when:
-    - falcon_api_oauth2_token is defined
+    - falcon.auth is defined
     - falcon_remove_host
     - falcon_sensor_installed
   block:
@@ -45,7 +45,7 @@
 # Hide host
 - name: Hide host
   when:
-    - falcon_client_id and falcon_client_secret
+    - falcon.auth is defined
     - falcon_uninstall_remove_aid is defined
   block:
     - ansible.builtin.include_tasks: hide_host.yml


### PR DESCRIPTION
This PR introduces the `host_hide` module. This is the final API call to complete the roles. 

This also updates all the README's to ensure they all follow the same formatting. A few minor fixes here and there as well.