### PR TITLE
Do not throw errors when running falcon_install and falcon_configure roles in Ansible check mode

### DIFF
--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -28,6 +28,7 @@
         state: "{{ falcon_service_state | default('restarted') }}"
         enabled: yes
       when:
+        - not ansible_check_mode
         - info.falconctl_info.cid
         - falconctl_result.changed
       become: yes

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -77,7 +77,9 @@
     mode: 0640
   changed_when: false
   register: falcon_sensor_copied
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Windows"
+    - falcon_sensor_download.changed
 
 - name: CrowdStrike Falcon | Copy Sensor Installation Package to remote host (windows)
   ansible.windows.win_copy:
@@ -86,7 +88,9 @@
     mode: 0640
   changed_when: false
   register: win_falcon_sensor_copied
-  when: ansible_os_family == "Windows"
+  when: 
+    - ansible_os_family == "Windows"
+    - falcon_sensor_download.changed
 
 - name: CrowdStrike Falcon | Remove Downloaded Sensor Installation Package (local)
   ansible.builtin.file:
@@ -99,9 +103,13 @@
 - name: CrowdStrike Falcon | Set full file download path (non-windows)
   ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ falcon_sensor_copied.dest }}"
-  when: ansible_os_family != "Windows"
+  when: 
+    - ansible_os_family != "Windows"
+    - falcon_sensor_download.changed
 
 - name: CrowdStrike Falcon | Set full file download path (windows)
   ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ win_falcon_sensor_copied.dest }}\\{{ win_falcon_sensor_copied.original_basename }}"
-  when: ansible_os_family == "Windows"
+  when:
+    - ansible_os_family == "Windows"
+    - falcon_sensor_download.changed

--- a/roles/falcon_install/tasks/install.yml
+++ b/roles/falcon_install/tasks/install.yml
@@ -14,6 +14,7 @@
   loop: "{{ falcon_gpg_keys }}"
   when:
     - falcon_gpg_key_check
+    - falcon_install_temp_directory.path is defined
 
 - name: CrowdStrike Falcon | Import CrowdStrike Falcon RPM GPG key from files
   ansible.builtin.rpm_key:
@@ -24,6 +25,7 @@
   when:
     - falcon_gpg_key_check
     - ansible_facts['pkg_mgr'] in rpm_packagers
+    - falcon_install_temp_directory.path is defined
 
 - name: CrowdStrike Falcon | Import CrowdStrike Falcon APT GPG key from file
   ansible.builtin.apt_key:
@@ -33,6 +35,7 @@
   when:
     - falcon_gpg_key_check
     - ansible_facts['pkg_mgr'] in dpkg_packagers
+    - falcon_install_temp_directory.path is defined
 
 - name: CrowdStrike Falcon | Install Falcon Sensor Package (Linux)
   ansible.builtin.package:
@@ -43,6 +46,7 @@
     state: present
   when:
     - ansible_facts['pkg_mgr'] in linux_packagers
+    - not ansible_check_mode
 
 - name: CrowdStrike Falcon | Install Falcon Sensor .pkg Package (macOS)
   ansible.builtin.command: "/usr/sbin/installer -pkg {{ falcon_sensor_pkg }} -target /"


### PR DESCRIPTION
This PR adds better support for running falcon_install and falcon_configure roles in Ansible check mode.

Fixes errors like this when running in check mode:
```
fatal: [machine.xyz]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'path'. 'dict object' has no attribute 'path'\n\nThe error appears to be in '/home/user/.ansible/collections/ansible_collections/crowdstrike/falcon/roles/falcon_install/tasks/api.yml': line 73, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: CrowdStrike Falcon | Copy Sensor Installation Package to remote host (non-windows)\n  ^ here\n"}

```