### PR TITLE
Update ansible lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,8 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ansible/ansible-lint-action@main
-      with:
-        targets: roles
-        override-deps: |
-          rich>=9.5.1,<11.0.0
+    - uses: ansible/ansible-lint@v6.22.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.16.0
+    rev: v6.22.1
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -80,7 +80,6 @@ EXAMPLES = r"""
   fail:
     msg: "Hosts could not be hidden: {{ hide_result.failed_hosts }}"
   when: hide_result.failed_hosts | length > 0
-
 """
 
 RETURN = r"""


### PR DESCRIPTION
For certification, ensure we are passing on ansible-lint 6.22.x+