### PR TITLE
chore: remove dep on eda collection and update core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you encounter any issues or have questions about the migration, please open a
 
 ## Ansible version compatibility
 
-Tested with the Ansible Core >= 2.13.0 versions, and the current development version of Ansible. Ansible Core versions before 2.13.0 are not supported.
+Tested with the Ansible Core >= 2.14.0 versions, and the current development version of Ansible. Ansible Core versions before 2.14.0 are not supported.
 
 ## Python version compatibility
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -53,7 +53,6 @@ tags:
 # range specifiers can be set and are separated by ','
 dependencies:
   "ansible.windows": ">=1.7.2"
-  "ansible.eda": ">=1.4.2"
 
 # The URL of the originating SCM repository
 repository: https://github.com/CrowdStrike/ansible_collection_crowdstrike


### PR DESCRIPTION
can't find any good examples where the ansible.eda collection is a dependency for a collection that authors an event_source plugin for eda. This was affecting creation of DE and EE for AAP.