### PR TITLE
chore: update sles ec2 image for workflows

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -57,10 +57,10 @@ jobs:
             image_arch: x86_64
             image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
-          - distro: sles-15-sp4
+          - distro: sles-15-sp5
             image_owner: '013907871322'
             image_arch: x86_64
-            image_name: suse-sles-15-sp4-v????????-hvm*
+            image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
           - distro: centos-7
             image_owner: '679593333241'

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -57,10 +57,10 @@ jobs:
             image_arch: x86_64
             image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
-          - distro: sles-15-sp4
+          - distro: sles-15-sp5
             image_owner: '013907871322'
             image_arch: x86_64
-            image_name: suse-sles-15-sp4-v????????-hvm*
+            image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
           - distro: centos-7
             image_owner: '679593333241'

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -57,10 +57,10 @@ jobs:
             image_arch: x86_64
             image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
-          - distro: sles-15-sp4
+          - distro: sles-15-sp5
             image_owner: '013907871322'
             image_arch: x86_64
-            image_name: suse-sles-15-sp4-v????????-hvm*
+            image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
           - distro: centos-7
             image_owner: '679593333241'


### PR DESCRIPTION
CI is failing because `suse-sles-15-sp4-v????????-hvm*` is no longer valid.