### PR TITLE
Remove superfluous param from get_bin_path

### DIFF
--- a/changelogs/fragments/get_bin_path.yml
+++ b/changelogs/fragments/get_bin_path.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove superfluous parameter `required` from process.get_bin_path API usage.

--- a/plugins/module_utils/falconctl_utils.py
+++ b/plugins/module_utils/falconctl_utils.py
@@ -44,7 +44,7 @@ FALCONCTL_NOT_FOUND = False
 FALCONCTL_VALUE_ERROR = None
 _cs_path = "/opt/CrowdStrike"
 try:
-    _FALCONCTL = get_bin_path("falconctl", required=True, opt_dirs=[_cs_path])
+    _FALCONCTL = get_bin_path("falconctl", opt_dirs=[_cs_path])
 except ValueError:
     FALCONCTL_NOT_FOUND = True
     FALCONCTL_VALUE_ERROR = traceback.format_exc()


### PR DESCRIPTION
##### SUMMARY

The parameter `required` in process.get_bin_path is useless.
Remove and update the usage of get_bin_path in inventory and lookup
plugins.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


