### PR TITLE
chore: ensure tags on cicd hosts to allow cleanup on console

### DIFF
--- a/molecule/falcon_configure/converge.yml
+++ b/molecule/falcon_configure/converge.yml
@@ -11,7 +11,7 @@
         falcon_option_set: yes
         falcon_cid: "{{ lookup('env', 'FALCON_CID') }}"
         falcon_provisioning_token: '12345678'
-        falcon_tags: 'falcon,example,tags'
+        falcon_tags: 'molecule,testing'
         falcon_billing: 'metered'
         falcon_message_log: yes
         falcon_backend: 'kernel'

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -46,7 +46,6 @@
     vars:
       falcon_option_set: no
       falcon_cid: ""
-      falcon_tags: ""
       falcon_billing: ""
       falcon_apd: ""
       falcon_aph: ""
@@ -71,17 +70,19 @@
           that:
             - not delete_info.falconctl_info.aid
             - not delete_info.falconctl_info.cid
-            - not delete_info.falconctl_info.tags
             - not delete_info.falconctl_info.apd
             - not delete_info.falconctl_info.aph
             - not delete_info.falconctl_info.app
 
-  - name: Test auto-detecting CID
-    ansible.builtin.include_role:
-      name: crowdstrike.falcon.falcon_configure
-    vars:
-      falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
-      falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+  - name: Auto-detect CID block
+    become: no
+    block:
+      - name: Test auto-detecting CID
+        ansible.builtin.include_role:
+          name: crowdstrike.falcon.falcon_configure
+        vars:
+          falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+          falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
 
   - name: Get CID Option
     crowdstrike.falcon.falconctl_info:

--- a/molecule/falcon_uninstall/prepare.yml
+++ b/molecule/falcon_uninstall/prepare.yml
@@ -38,3 +38,4 @@
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+        falcon_tags: 'molecule,testing'

--- a/molecule/win_falcon_configure/prepare.yml
+++ b/molecule/win_falcon_configure/prepare.yml
@@ -1,10 +1,12 @@
 ---
 - name: Prepare
   hosts: all
+  vars:
+    windows_install_args: "/norestart GROUPING_TAGS=molecule,testing"
   tasks:
     - name: Set ProvToken info (if applicable)
       ansible.builtin.set_fact:
-        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+        windows_install_args: "{{ windows_install_args }} ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
       when: lookup('env', 'FALCON_PROV_TOKEN')
 
     - name: Install Falcon Sensor
@@ -13,4 +15,4 @@
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
-        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"
+        falcon_windows_install_args: "{{ windows_install_args }}"

--- a/molecule/win_falcon_install/converge.yml
+++ b/molecule/win_falcon_install/converge.yml
@@ -1,10 +1,12 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    windows_install_args: "/norestart GROUPING_TAGS=molecule,testing"
   tasks:
     - name: Set ProvToken info (if applicable)
       ansible.builtin.set_fact:
-        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+        windows_install_args: "{{ windows_install_args }} ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
       when: lookup('env', 'FALCON_PROV_TOKEN')
 
     - name: Install Falcon Sensor
@@ -13,4 +15,4 @@
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
-        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"
+        falcon_windows_install_args: "{{ windows_install_args }}"

--- a/molecule/win_falcon_install_policy/converge.yml
+++ b/molecule/win_falcon_install_policy/converge.yml
@@ -1,10 +1,12 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    windows_install_args: "/norestart GROUPING_TAGS=molecule,testing"
   tasks:
     - name: Set ProvToken info (if applicable)
       ansible.builtin.set_fact:
-        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+        windows_install_args: "{{ windows_install_args }} ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
       when: lookup('env', 'FALCON_PROV_TOKEN')
 
     - name: Install Falcon Sensor
@@ -14,4 +16,4 @@
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
         falcon_sensor_update_policy_name: "platform_default"
-        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"
+        falcon_windows_install_args: "{{ windows_install_args }}"

--- a/molecule/win_falcon_uninstall/prepare.yml
+++ b/molecule/win_falcon_uninstall/prepare.yml
@@ -1,10 +1,12 @@
 ---
 - name: Prepare
   hosts: all
+  vars:
+    windows_install_args: "/norestart GROUPING_TAGS=molecule,testing"
   tasks:
     - name: Set ProvToken info (if applicable)
       ansible.builtin.set_fact:
-        windows_install_args: "/norestart ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
+        windows_install_args: "{{ windows_install_args }} ProvToken={{ lookup('env', 'FALCON_PROV_TOKEN') }}"
       when: lookup('env', 'FALCON_PROV_TOKEN')
 
     - name: Install Falcon Sensor
@@ -13,4 +15,4 @@
       vars:
         falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
         falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
-        falcon_windows_install_args: "{{ windows_install_args if windows_install_args is defined else '/norestart' }}"
+        falcon_windows_install_args: "{{ windows_install_args }}"


### PR DESCRIPTION
Fixes #424

This PR ensures that sensors installed during ci/cd runs have the same grouping tags applied. This will make it easier to clean up on the console side.