### PR TITLE
Fix documentation regarding falcon_aph/aph

### DIFF
--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -26,7 +26,7 @@
       name: crowdstrike.falcon.falcon_configure
     vars:
       falcon_apd: no
-      falcon_aph: 'http://example.com'
+      falcon_aph: 'example.com'
       falcon_app: 8080
 
   - name: Get list of Falcon Sensor Proxy Options
@@ -37,7 +37,7 @@
     ansible.builtin.assert:
       that:
         - proxy_info.falconctl_info.apd == 'FALSE'
-        - proxy_info.falconctl_info.aph == 'http://example.com'
+        - proxy_info.falconctl_info.aph == 'example.com'
         - proxy_info.falconctl_info.app == '8080'
 
   - name: Test Deleting Options

--- a/plugins/modules/falconctl.py
+++ b/plugins/modules/falconctl.py
@@ -127,7 +127,7 @@ EXAMPLES = r"""
   crowdstrike.falcon.falconctl:
     state: present
     apd: no
-    aph: http://example.com
+    aph: example.com
     app: 8080
 """
 

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -49,7 +49,7 @@ future.
 - `falcon_provisioning_token` - Falcon Installation Token (string, default: ***null***)
 - `falcon_apd` - Enable/Disable the Falcon Proxy (string, default: ***null***)
   > To enable proxy, set as: ***false***
-- `falcon_aph` - Falcon Proxy host (by FQDN or IP) (string, default: ***null***)
+- `falcon_aph` - Falcon Proxy host (by FQDN or IP), without protocol (string, default: ***null***)
 - `falcon_app` - Falcon Proxy port (string, default: ***null***)
 - `falcon_trace` - Configure additional traces for debugging (string, default: ***null***)
 - `falcon_feature` - Configures additional features to the sensor (list, default: ***null***)
@@ -135,7 +135,7 @@ How to configure the Falcon Sensor Proxy:
   - role: crowdstrike.falcon.falcon_configure
     vars:
       falcon_apd: no
-      falcon_aph: 'http://example.com'
+      falcon_aph: 'example.com'
       falcon_app: 8080
 ```
 

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -61,7 +61,7 @@ falcon_remove_aid:
 #
 falcon_apd:
 
-# The Falcon Proxy host. Can be either the FQDN or IP.
+# The Falcon Proxy host. Can be either the FQDN or IP. Without protocol.
 #
 falcon_aph:
 


### PR DESCRIPTION
Affected roles:
- crowdstrike.falcon.falcon_configure

Affected modules:
- falconctl

All the documentation tells you to configure proxy with falcon_aph/aph with protocol included. 

```
falcon_aph: "http://{{ proxy__host }}"
```
However if you do that you will get the following

```
CrowdStrike(4): Connect: Unable to resolve http://<Proxy FQDN retracted>, getaddrinfo returned -2
```

To get proxy working you need to use following.

```
falcon_aph: "{{ proxy__host }}"
```

And the connection will work with proxy

```
CrowdStrike(4): trying to connect to <Proxy FQDN retracted>:8080
CrowdStrike(4): ProxyConnect: Connected successfully to "ts01-lanner-lion.cloudsink.net:443" via proxy "<Proxy FQDN retracted>:8080" 
```

This pull request aims to fix the documentation to reflect reality. 
