### PR TITLE
Fix examples regarding falcon_aph/aph

### DIFF
--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -25,7 +25,7 @@
       name: crowdstrike.falcon.falcon_configure
     vars:
       falcon_apd: no
-      falcon_aph: 'http://example.com'
+      falcon_aph: 'example.com'
       falcon_app: 8080
 
   - name: Get list of Falcon Sensor Proxy Options
@@ -36,7 +36,7 @@
     ansible.builtin.assert:
       that:
         - proxy_info.falconctl_info.apd == 'FALSE'
-        - proxy_info.falconctl_info.aph == 'http://example.com'
+        - proxy_info.falconctl_info.aph == 'example.com'
         - proxy_info.falconctl_info.app == '8080'
 
   - name: Test Deleting Options

--- a/plugins/modules/falconctl.py
+++ b/plugins/modules/falconctl.py
@@ -127,7 +127,7 @@ EXAMPLES = r"""
   crowdstrike.falcon.falconctl:
     state: present
     apd: no
-    aph: http://example.com
+    aph: example.com
     app: 8080
 """
 

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -135,7 +135,7 @@ How to configure the Falcon Sensor Proxy:
   - role: crowdstrike.falcon.falcon_configure
     vars:
       falcon_apd: no
-      falcon_aph: 'http://example.com'
+      falcon_aph: 'example.com'
       falcon_app: 8080
 ```
 


### PR DESCRIPTION
Affected roles:
- crowdstrike.falcon.falcon_configure

Affected modules:
- falconctl

All the documentation tells you to configure proxy with falcon_aph/aph with protocol included.

```
falcon_aph: "http://{{ proxy__host }}"

```

However if you do that you will get the following
```
CrowdStrike(4): Connect: Unable to resolve http://<Proxy FQDN retracted>, getaddrinfo returned -2
```
To get proxy working you need to use following.

```
falcon_aph: "{{ proxy__host }}"
```

And the connection will work with proxy

```
CrowdStrike(4): trying to connect to <Proxy FQDN retracted>:8080
CrowdStrike(4): ProxyConnect: Connected successfully to "<retracted CS server name>:443" via proxy "<Proxy FQDN retracted>:8080" 
```

This pull request aims to fix the documentation to reflect reality.

*used incorrect email in commit so had to redo. 