### PR TITLE
chore: update falcon-configure molecule

### DIFF
--- a/molecule/falcon_configure/converge.yml
+++ b/molecule/falcon_configure/converge.yml
@@ -13,7 +13,6 @@
         falcon_provisioning_token: '12345678'
         falcon_tags: 'molecule,testing'
         falcon_billing: 'metered'
-        falcon_message_log: yes
         falcon_backend: 'kernel'
         falcon_feature:
           - enableLog

--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -15,7 +15,6 @@
         - info.falconctl_info.cid
         - info.falconctl_info.billing
         - info.falconctl_info.tags
-        - info.falconctl_info.message_log
         - not info.falconctl_info.apd
         - not info.falconctl_info.aph
         - not info.falconctl_info.app


### PR DESCRIPTION
The message_log option is no longer valid for newer versions of the sensor.