### PR TITLE
Disable sudo for localhost auth

### DIFF
--- a/roles/falcon_install/tasks/auth.yml
+++ b/roles/falcon_install/tasks/auth.yml
@@ -7,6 +7,7 @@
   register: falcon
   run_once: yes
   no_log: "{{ falcon_api_enable_no_log }}"
+  become: no
   delegate_to: localhost
 
 - name: Set falcon_cid Block


### PR DESCRIPTION
Disables sudo for auth task so localhost doesn't have to have root.

See details at: https://github.com/CrowdStrike/ansible_collection_falcon/issues/467