### PR TITLE
feat: Add ability to change the permissions of the sensor file

### DIFF
--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -47,6 +47,7 @@ The following variables are currently supported:
 - `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: ***true***)
 - `falcon_api_sensor_download_path` - Local directory path to download the sensor to (string, default: ***null***)
 - `falcon_api_sensor_download_filename` - The name to save the sensor file as (string, default: ***null***)
+- `falcon_api_sensor_download_mode` - The permissions to save the sensor file with (int, default: ***null***)
 - `falcon_api_sensor_download_cleanup` - Whether or not to delete the downloaded sensor after transfer to remote host (bool, default: ***true***)
 - `falcon_sensor_version` - Sensor version to install (string, default: ***null***)
 - `falcon_sensor_version_decrement` - Sensor N-x version to install (int, default: ***0*** [latest])

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -34,6 +34,13 @@ falcon_api_sensor_download_path:
 #
 falcon_api_sensor_download_filename:
 
+# The permissions the saved sensor file should have.
+#
+# If not specified, the default umask on the system will be used when setting
+# the mode for the newly created filesystem object.
+#
+falcon_api_sensor_download_mode:
+
 # Whether or not to delete the downloaded sensor after transfer to remote host.
 #
 # By default, this is enabled.

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -70,6 +70,13 @@
   register: falcon_sensor_download
   delegate_to: localhost
 
+- name: CrowdStrike Falcon | Permissions of Falcon Sensor Installation Package (local)
+  ansible.builtin.file:
+    path: "{{ falcon_sensor_download.path }}"
+    mode: "{{ falcon_api_sensor_download_mode }}"
+  delegate_to: localhost
+  when: falcon_api_sensor_download_mode is defined
+
 - name: CrowdStrike Falcon | Copy Sensor Installation Package to remote host (non-windows)
   ansible.builtin.copy:
     src: "{{ falcon_sensor_download.path }}"


### PR DESCRIPTION
This has already been tested, setting the variable `falcon_api_sensor_download_mode` to `0644`.

**Before**:

```
TASK [crowdstrike.falcon.falcon_install : CrowdStrike Falcon | Copy Sensor Installation Package to remote host (non-windows)] *******************************************************
fatal: [i-0da31599f96a90199_asg-metadefender-image-ubuntu22-mdtest-202404050828]: FAILED! =>
  msg: 'an error occurred while trying to read the file ''/var/tmp/falcon-sensor_7.13.0-16604_amd64.deb'': [Errno 13] Permission denied: b''/var/tmp/falcon-sensor_7.13.0-16604_amd64.deb''. [Errno 13] Permission denied: b''/var/tmp/falcon-sensor_7.13.0-16604_amd64.deb'''
```

**After**:

```
TASK [crowdstrike.falcon.falcon_install : CrowdStrike Falcon | Permissions of Falcon Sensor Installation Package (local)] ***********************************************************
changed: [i-0da31599f96a90199_asg-metadefender-image-ubuntu22-mdtest-202404050828 -> localhost]

TASK [crowdstrike.falcon.falcon_install : CrowdStrike Falcon | Copy Sensor Installation Package to remote host (non-windows)] *******************************************************
ok: [i-0da31599f96a90199_asg-metadefender-image-ubuntu22-mdtest-202404050828]
```

Fixes: #481 