### PR TITLE
fix(sensor_download): add file operation support to module

### DIFF
--- a/changelogs/fragments/add-file-ops-sensor-download.yml
+++ b/changelogs/fragments/add-file-ops-sensor-download.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sensor_download: added the ability to set file permissions on downloaded files (https://github.com/CrowdStrike/ansible_collection_falcon/pull/485)

--- a/changelogs/fragments/add-file-ops-sensor-download.yml
+++ b/changelogs/fragments/add-file-ops-sensor-download.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - sensor_download: added the ability to set file permissions on downloaded files (https://github.com/CrowdStrike/ansible_collection_falcon/pull/485)
+  - sensor_download - added the ability to set file permissions on downloaded files (https://github.com/CrowdStrike/ansible_collection_falcon/pull/485)

--- a/plugins/modules/sensor_download.py
+++ b/plugins/modules/sensor_download.py
@@ -70,7 +70,7 @@ EXAMPLES = r"""
 - name: Download the Falcon Sensor Installer to a temporary directory and set permissions
   crowdstrike.falcon.sensor_download:
     hash: "1234567890123456789012345678901234567890123456789012345678901234"
-    mode: "0755"
+    mode: "0644"
     owner: "root"
     group: "root"
 """


### PR DESCRIPTION
Fixes #481

This PR introduces the built-in files AnsibleModule helper features to manage file operations such as mode, owner, group, etc.