### PR TITLE
fix(falcon_configure): update logic for removing aid

### DIFF
--- a/molecule/falcon_configure/verify.yml
+++ b/molecule/falcon_configure/verify.yml
@@ -57,7 +57,6 @@
         ansible.builtin.include_role:
           name: crowdstrike.falcon.falcon_configure
         vars:
-          falcon_option_set: no
           falcon_remove_aid: yes
 
       - name: Get Updated Falcon Sensor Option

--- a/molecule/falcon_configure_remove_aid/converge.yml
+++ b/molecule/falcon_configure_remove_aid/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+  become: yes
+  vars:
+    falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+    falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"
+  roles:
+    - role: crowdstrike.falcon.falcon_configure
+      vars:
+        falcon_option_set: yes
+        falcon_cid: "{{ lookup('env', 'FALCON_CID') }}"
+        falcon_tags: 'molecule,testing'
+        falcon_backend: 'bpf'
+        falcon_remove_aid: yes

--- a/molecule/falcon_configure_remove_aid/molecule.yml
+++ b/molecule/falcon_configure_remove_aid/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: ec2
+# The Default Platform is Ubunutu 20.04 LTS | T2.Micro | us-west-2
+platforms:
+  - name: "${MOLECULE_INSTANCE_NAME:-default-falcon-configure-remove-aid}"
+    image_owner: "${MOLECULE_IMAGE_OWNER:-099720109477}"
+    image_filters:
+      - architecture: "${MOLECULE_IMAGE_ARCH:-x86_64}"
+      - name: "${MOLECULE_IMAGE_NAME:-ubuntu/images/hvm-ssd/ubuntu-focal-20.04*}"
+    instance_type: "${MOLECULE_INSTANCE_TYPE:-t2.micro}"
+    region: "${MOLECULE_REGION:-us-west-2}"
+    vpc_subnet_id: "${MOLECULE_VPC_SUBNET_ID}"
+    security_group_restrict_cidr_ip: "${MOLECULE_SECURITY_GROUP_RESTRICT_CIDR_IP:-true}"
+    boot_wait_seconds: ${MOLECULE_BOOT_WAIT_SECONDS:-10}
+provisioner:
+  name: ansible
+  playbooks:
+    create: ../shared/playbooks/create.yml
+    destroy: ../shared/playbooks/destroy.yml
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - destroy

--- a/molecule/falcon_configure_remove_aid/prepare.yml
+++ b/molecule/falcon_configure_remove_aid/prepare.yml
@@ -1,0 +1,29 @@
+---
+- name: Prepare
+  hosts: all
+  become: yes
+  tasks:
+    # Ubuntu specific
+    - name: Install apt dependencies
+      ansible.builtin.apt:
+        name:
+          - gpg-agent
+        update_cache: yes
+      ignore_errors: yes
+      when: ansible_facts['pkg_mgr'] == 'apt'
+
+    - name: Install dependencies
+      ansible.builtin.package:
+        name:
+          - sudo
+        state: present
+
+- name: Install CrowdStrike Falcon Sensor
+  hosts: all
+  tasks:
+    - name: Install Falcon Sensor
+      ansible.builtin.include_role:
+        name: crowdstrike.falcon.falcon_install
+      vars:
+        falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
+        falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"

--- a/molecule/falcon_configure_remove_aid/verify.yml
+++ b/molecule/falcon_configure_remove_aid/verify.yml
@@ -1,0 +1,21 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  become: yes
+  tasks:
+  - name: Get list of Falcon Sensor Options
+    crowdstrike.falcon.falconctl_info:
+    register: info
+
+  - name: Verify Falcon Sensor options are set
+    ansible.builtin.assert:
+      that:
+        - info.falconctl_info.cid
+        - info.falconctl_info.tags
+
+  - name: Verify AID is not present
+    ansible.builtin.assert:
+      that:
+        - not info.falconctl_info.aid

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -4,17 +4,17 @@
   block:
     - name: CrowdStrike Falcon | Configure Falcon Sensor Options (Linux)
       crowdstrike.falcon.falconctl:
-        cid: "{{ falcon_cid if (falcon_cid != None) else omit }}"
-        provisioning_token: "{{ falcon_provisioning_token if (falcon_provisioning_token != None) else omit }}"
-        apd: "{{ falcon_apd if (falcon_apd != None) else omit }}"
-        aph: "{{ falcon_aph if (falcon_aph != None) else omit }}"
-        app: "{{ falcon_app if (falcon_app != None) else omit }}"
-        trace: "{{ falcon_trace if (falcon_trace != None) else omit }}"
-        feature: "{{ falcon_feature if (falcon_feature != None) else omit }}"
-        message_log: "{{ falcon_message_log if (falcon_message_log != None) else omit }}"
-        billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
-        tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
-        backend: "{{ falcon_backend if (falcon_backend != None) else omit }}"
+        cid: "{{ options.cid }}"
+        provisioning_token: "{{ options.provisioning_token }}"
+        apd: "{{ options.apd }}"
+        aph: "{{ options.aph }}"
+        app: "{{ options.app }}"
+        trace: "{{ options.trace }}"
+        feature: "{{ options.feature }}"
+        message_log: "{{ options.message_log }}"
+        billing: "{{ options.billing }}"
+        tags: "{{ options.tags }}"
+        backend: "{{ options.backend }}"
         state: "{{ 'present' if falcon_option_set else 'absent' }}"
       register: falconctl_result
 
@@ -30,9 +30,29 @@
       when:
         - info.falconctl_info.cid
         - falconctl_result.changed
-      become: yes
       # noqa args[module]
       # noqa no-handler
+
+    # Wait for aid to be generated
+    - name: CrowdStrike Falcon | Wait for Falcon Sensor to Generate AID
+      crowdstrike.falcon.falconctl_info:
+        name:
+          - aid
+      register: info
+      retries: 6
+      delay: 10
+      until: info.falconctl_info.aid
+      when:
+        - info.falconctl_info.cid
+        - falconctl_result.changed
+      # noqa no-handler
+
+    - name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
+      crowdstrike.falcon.falconctl:
+        aid: yes
+        state: absent
+      when:
+        - falcon_remove_aid
 
 # Start of MacOSX Configuration
 - name: CrowdStrike Falcon | Stat Falcon Sensor (macOS)

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -11,10 +11,14 @@
         tasks_from: auth
       # noqa name[missing]
 
+- name: Checks if any options are set
+  ansible.builtin.set_fact:
+    any_option_set: "{{ true if (options | dict2items | selectattr('value', 'ne', omit) | list | length > 0) else false }}"
+
 - name: Linux Configure block
   when:
     - ansible_facts['os_family'] != "Windows"
-    - not falcon_remove_aid
+    - any_option_set
   become: true
   become_user: root
   block:
@@ -24,6 +28,7 @@
 - name: Remove AID block
   when:
     - falcon_remove_aid
+    - not any_option_set
     - ansible_facts['os_family'] != "Windows"
   become: true
   become_user: root

--- a/roles/falcon_configure/vars/main.yml
+++ b/roles/falcon_configure/vars/main.yml
@@ -5,3 +5,16 @@ falcon_cloud_urls:
   us-2: "api.us-2.crowdstrike.com"
   eu-1: "api.eu-1.crowdstrike.com"
   us-gov-1: "api.laggar.gcw.crowdstrike.com"
+
+options:
+  cid: "{{ falcon_cid if (falcon_cid != None) else omit }}"
+  provisioning_token: "{{ falcon_provisioning_token if (falcon_provisioning_token != None) else omit }}"
+  apd: "{{ falcon_apd if (falcon_apd != None) else omit }}"
+  aph: "{{ falcon_aph if (falcon_aph != None) else omit }}"
+  app: "{{ falcon_app if (falcon_app != None) else omit }}"
+  trace: "{{ falcon_trace if (falcon_trace != None) else omit }}"
+  feature: "{{ falcon_feature if (falcon_feature != None) else omit }}"
+  message_log: "{{ falcon_message_log if (falcon_message_log != None) else omit }}"
+  billing: "{{ falcon_billing if (falcon_billing != None) else omit }}"
+  tags: "{{ falcon_tags if (falcon_tags != None) else omit }}"
+  backend: "{{ falcon_backend if (falcon_backend != None) else omit }}"


### PR DESCRIPTION
In this pull request, the following changes are made to provide backwards compatibility to existing removal of aid workflows:

- Moved all the option checking logic to default variables stored as a dictionary. This restructuring simplifies the process of checking if any options have been set with jinja2.
- Updated the existing configure task to utilize the new options dictionary.
- Addressed a race condition where having a task immediately after restarting the sensor on a fresh install/configuration could occur. To mitigate this, a wait condition has been implemented until an AID is present.

With these changes, the pull request now accommodates two scenarios:
1. Proper gold image workflow: install -> (configure + remove aid)
2. Removal of the AID as a singleton job.

---
Added new molecule scenario to test the normal VM template/Gold Image workflow.
