### PR TITLE
fix(falcon_install): add ability to use file ownership changes from sensor_download module

### DIFF
--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -5,7 +5,6 @@ This role installs the CrowdStrike Falcon Sensor. It provides the flexibility to
 > [!NOTE]
 > Please note that for Linux and macOS, this role only handles the installation of the sensor. To configure and start the sensor, please use the [falcon_configure](../falcon_configure/) role after the sensor is installed.
 
-
 ## Requirements
 
 - Ansible 2.13 or higher
@@ -46,6 +45,9 @@ The following variables are currently supported:
     - **eu-1** -> api.eu-1.crowdstrike.com
 - `falcon_api_enable_no_log` - Whether to enable or disable the logging of sensitive data being exposed in API calls (bool, default: ***true***)
 - `falcon_api_sensor_download_path` - Local directory path to download the sensor to (string, default: ***null***)
+- `falcon_api_sensor_download_mode` - The file permissions to set on the downloaded sensor (string, default: ***null***)
+- `falcon_api_sensor_download_owner` - The owner to set on the downloaded sensor (string, default: ***null***)
+- `falcon_api_sensor_download_group` - The group to set on the downloaded sensor (string, default: ***null***)
 - `falcon_api_sensor_download_filename` - The name to save the sensor file as (string, default: ***null***)
 - `falcon_api_sensor_download_cleanup` - Whether or not to delete the downloaded sensor after transfer to remote host (bool, default: ***true***)
 - `falcon_sensor_version` - Sensor version to install (string, default: ***null***)

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -34,6 +34,25 @@ falcon_api_sensor_download_path:
 #
 falcon_api_sensor_download_filename:
 
+# The permissions of the downloaded sensor file.
+#
+# If not specified, the default permissions based on the OS/filesystem will be used.
+# Example: '0644'
+#
+falcon_api_sensor_download_mode:
+
+# The owner to set the downloaded sensor file as.
+#
+# If not specified, the default owner based on the OS/filesystem will be used.
+#
+falcon_api_sensor_download_owner:
+
+# The group to set the downloaded sensor file as.
+#
+# If not specified, the default group based on the OS/filesystem will be used.
+#
+falcon_api_sensor_download_group:
+
 # Whether or not to delete the downloaded sensor after transfer to remote host.
 #
 # By default, this is enabled.

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -66,6 +66,9 @@
     hash: "{{ falcon_api_installer_list.installers[falcon_sensor_version_decrement | int].sha256 }}"
     dest: "{{ falcon_api_sensor_download_path | default(omit, true) }}"
     name: "{{ falcon_api_sensor_download_filename | default(omit, true) }}"
+    mode: "{{ falcon_api_sensor_download_mode | default(omit, true) }}"
+    owner: "{{ falcon_api_sensor_download_owner | default(omit, true) }}"
+    group: "{{ falcon_api_sensor_download_group | default(omit, true) }}"
   changed_when: false
   register: falcon_sensor_download
   delegate_to: localhost


### PR DESCRIPTION
This PR adds the ability to take advantage of passing in mode/owner/group permissions to the sensor download task that were introduced by #485 