### PR TITLE
Minor updates for 4.4.0 prep

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -74,5 +74,4 @@ build_ignore:
   - '.devcontainer'
   - '.git*'
   - '.pre-commit-config.yaml'
-  - 'docs'
   - 'tox.ini'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
Fixes #508 

Updating Ansible core requirements due to certification requirements for EOS to AAP 2.3.