### PR TITLE
fix(sensor_download_info): use v2 override for new endpoint

### DIFF
--- a/plugins/modules/sensor_download_info.py
+++ b/plugins/modules/sensor_download_info.py
@@ -24,6 +24,7 @@ options:
     description:
       - The maximum number of records to return. [1-500]
       - Use with the offset parameter to manage pagination of results.
+    default: 100
     type: int
 
 extends_documentation_fragment:
@@ -49,6 +50,10 @@ EXAMPLES = r"""
     limit: 2
     filter: "platform:'windows'"
     sort: "version|desc"
+
+- name: Get all zLinux(s390x) Sensor Installers
+  crowdstrike.falcon.sensor_download_info:
+    filter: "platform:'linux' + architectures:'s390x'"
 """
 
 RETURN = r"""
@@ -110,6 +115,12 @@ installers:
       returned: success
       type: str
       sample: 6.22.11404
+    architectures:
+      description: A list of architectures supported by the Sensor Installer.
+      returned: success
+      type: list
+      elements: str
+      sample: x86_64
 """
 
 import traceback
@@ -135,7 +146,7 @@ except ImportError:
 
 DOWNLOAD_INFO_ARGS = {
     "filter": {"type": "str", "required": False},
-    "limit": {"type": "int", "required": False},
+    "limit": {"type": "int", "required": False, "default": 100},
     "offset": {"type": "int", "required": False},
     "sort": {"type": "str", "required": False},
 }
@@ -170,7 +181,7 @@ def main():
 
     falcon = authenticate(module, SensorDownload)
 
-    query_result = falcon.get_combined_sensor_installers_by_query(**args)
+    query_result = falcon.override("GET", "/sensors/combined/installers/v2", parameters={**args})
 
     result = dict(
         changed=False,

--- a/plugins/modules/sensor_download_info.py
+++ b/plugins/modules/sensor_download_info.py
@@ -20,17 +20,20 @@ description:
   - Returns a set of Sensor Installers which match the filter criteria.
 
 options:
+  filter:
+    description:
+      - The filter expression that should be used to limit the results using FQL (Falcon Query Language) syntax.
+      - See the return values or CrowdStrike docs for more information about the available filters that can be used.
+    type: str
   limit:
     description:
       - The maximum number of records to return. [1-500]
-      - Use with the offset parameter to manage pagination of results.
     default: 100
     type: int
 
 extends_documentation_fragment:
   - crowdstrike.falcon.credentials
   - crowdstrike.falcon.credentials.auth
-  - crowdstrike.falcon.info
   - crowdstrike.falcon.info.sort
 
 requirements:
@@ -41,9 +44,10 @@ author:
 """
 
 EXAMPLES = r"""
-- name: Get a list of Linux Sensor Installers
+- name: Get a list of all Linux Sensor Installers
   crowdstrike.falcon.sensor_download_info:
     filter: "platform:'linux'"
+    limit: 200
 
 - name: Get a list of the 2 latest Windows Sensor Installers
   crowdstrike.falcon.sensor_download_info:


### PR DESCRIPTION
To maintain backwards compatability with FalconPy, we take advantage of the override feature that allows us to use the new sensors/combined/installers/v2 endpoint. This means we can now pass in architectures as a filter.

This also updates the limit to ensure users know the default limit is set to 100.

Closes #488 