### PR TITLE
fix(falcon_install): pass in the appropriate filter for architecture

### DIFF
--- a/changelogs/fragments/v2-sensor-installers.yml
+++ b/changelogs/fragments/v2-sensor-installers.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- sensor_download_info - fix offset and use override for v2 endpoint (https://github.com/CrowdStrike/ansible_collection_falcon/pull/520)
+- falcon_install - fix filter to take advantage of new architectures field (https://github.com/CrowdStrike/ansible_collection_falcon/pull/521)

--- a/plugins/modules/sensor_download_info.py
+++ b/plugins/modules/sensor_download_info.py
@@ -151,7 +151,6 @@ except ImportError:
 DOWNLOAD_INFO_ARGS = {
     "filter": {"type": "str", "required": False},
     "limit": {"type": "int", "required": False, "default": 100},
-    "offset": {"type": "int", "required": False},
     "sort": {"type": "str", "required": False},
 }
 

--- a/roles/falcon_install/vars/main.yml
+++ b/roles/falcon_install/vars/main.yml
@@ -24,6 +24,6 @@ falcon_cloud_urls:
   us-gov-1: "api.laggar.gcw.crowdstrike.com"
 
 falcon_os_arch_dict:
-  x86_64: "+os_version:!~'arm64'+os_version:!~'zLinux'"
-  aarch64: "+os_version:~'arm64'"
-  s390x: "+os_version:~'zLinux'"
+  x86_64: "+architectures:'x86_64'"
+  aarch64: "+architectures:'arm64'"
+  s390x: "+architectures:'s390x'"


### PR DESCRIPTION
Closes #489 

This PR updates the `falcon_install` role to take advantage of the new #520 V2 API endpoint updates that allows us to query an architecture now.

Instead of doing the following to only get x86_64 installers:

```yaml
x86_64: "+os_version:!~'arm64'+os_version:!~'zLinux'"
```

We can do this:
```yaml
x86_64: "+architectures:'x86_64'"
```