### PR TITLE
fix(falcon_uninstall): added missing become clause to pretask

### DIFF
--- a/molecule/falcon_uninstall/converge.yml
+++ b/molecule/falcon_uninstall/converge.yml
@@ -1,7 +1,6 @@
 ---
 - name: Converge
   hosts: all
-  become: yes
   vars:
     falcon_client_id: "{{ lookup('env', 'FALCON_CLIENT_ID') }}"
     falcon_client_secret: "{{ lookup('env', 'FALCON_CLIENT_SECRET') }}"

--- a/roles/falcon_uninstall/tasks/main.yml
+++ b/roles/falcon_uninstall/tasks/main.yml
@@ -19,6 +19,8 @@
     - falcon.auth is defined
     - falcon_remove_host
     - falcon_sensor_installed
+  become: true
+  become_user: root
   block:
     - ansible.builtin.include_tasks: remove_host_pretasks.yml
       # noqa name[missing]


### PR DESCRIPTION
Fixes #527

The `main.yml` tasks was missing the become clause for the remove host pretasks.

Also fixes the molecule job that would have caught this if it was configured correctly 🤦🏼‍♂️ 