### PR TITLE
fix(falcon_uninstall): configure become properly for remove_host_pretask.yml

### DIFF
--- a/changelogs/fragments/uninstall-become.yml
+++ b/changelogs/fragments/uninstall-become.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- falcon_uninstall - fix become clause for remove_host_pretasks.yml (https://github.com/CrowdStrike/ansible_collection_falcon/pull/532)

--- a/roles/falcon_uninstall/tasks/main.yml
+++ b/roles/falcon_uninstall/tasks/main.yml
@@ -19,8 +19,6 @@
     - falcon.auth is defined
     - falcon_remove_host
     - falcon_sensor_installed
-  become: true
-  become_user: root
   block:
     - ansible.builtin.include_tasks: remove_host_pretasks.yml
       # noqa name[missing]

--- a/roles/falcon_uninstall/tasks/remove_host_pretasks.yml
+++ b/roles/falcon_uninstall/tasks/remove_host_pretasks.yml
@@ -4,6 +4,8 @@
 - name: "CrowdStrike Falcon | Linux AID Block"
   when:
     - ansible_facts['system'] == 'Linux'
+  become: true
+  become_user: root
   block:
     - name: "CrowdStrike Falcon | Grab existing AID (Linux)"
       crowdstrike.falcon.falconctl_info:
@@ -25,6 +27,9 @@
 - name: "CrowdStrike Falcon | Windows AID Block"
   when:
     - ansible_facts['os_family'] == "Windows"
+  become: true
+  become_method: "{{ falcon_windows_become_method }}"
+  become_user: "{{ falcon_windows_become_user }}"
   block:
     - name: "CrowdStrike Falcon | Grab existing AID (Windows)"
       ansible.windows.win_reg_stat:
@@ -70,6 +75,8 @@
   when:
     - ansible_facts['distribution'] == "MacOSX"
     - falconctl_mac.stat.exists
+  become: true
+  become_user: root
   block:
     - name: CrowdStrike Falcon | Get AID Value from Stats (macOS)
       ansible.builtin.command: |


### PR DESCRIPTION
Fixes #531 
After the last change in PR#529, this caused an issue obviously for Windows since become method and user were incorrect. This PR makes the become clauses inline with the appropriate blocks.