### PR TITLE
ci: remove centos-7 from molecule testing

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -62,11 +62,6 @@ jobs:
             image_arch: x86_64
             image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
-          - distro: centos-7
-            image_owner: '679593333241'
-            image_arch: x86_64
-            image_name: CentOS-7-*
-            instance_type: t2.micro
           - distro: almalinux-8
             image_owner: '679593333241'
             image_arch: x86_64

--- a/.github/workflows/falcon_configure_remove_aid.yml
+++ b/.github/workflows/falcon_configure_remove_aid.yml
@@ -62,11 +62,6 @@ jobs:
             image_arch: x86_64
             image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
-          - distro: centos-7
-            image_owner: '679593333241'
-            image_arch: x86_64
-            image_name: CentOS-7-*
-            instance_type: t2.micro
           - distro: almalinux-8
             image_owner: '679593333241'
             image_arch: x86_64

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -62,11 +62,6 @@ jobs:
             image_arch: x86_64
             image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
-          - distro: centos-7
-            image_owner: '679593333241'
-            image_arch: x86_64
-            image_name: CentOS-7-*
-            instance_type: t2.micro
           - distro: almalinux-8
             image_owner: '679593333241'
             image_arch: x86_64

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -62,11 +62,6 @@ jobs:
             image_arch: x86_64
             image_name: suse-sles-15-sp5-v????????-hvm*
             instance_type: t2.micro
-          - distro: centos-7
-            image_owner: '679593333241'
-            image_arch: x86_64
-            image_name: CentOS-7-*
-            instance_type: t2.micro
           - distro: almalinux-8
             image_owner: '679593333241'
             image_arch: x86_64


### PR DESCRIPTION
Centos 7 is EOS so CI jobs fail due to no more repositories available/supported to install applications.