### PR TITLE
Master image updates

### DIFF
--- a/.github/workflows/falcon_configure_remove_aid.yml
+++ b/.github/workflows/falcon_configure_remove_aid.yml
@@ -27,6 +27,7 @@ jobs:
       ANSIBLE_FORCE_COLOR: 1
       FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
+      FALCON_PROV_TOKEN: ${{ secrets.FALCON_PROV_TOKEN }}
       FALCON_CID: ${{ secrets.FALCON_CID }}
       AWS_REGION: "us-west-2"
       MOLECULE_VPC_SUBNET_ID: ${{ secrets.MOLECULE_VPC_SUBNET_ID }}

--- a/changelogs/fragments/master-image-update.yml
+++ b/changelogs/fragments/master-image-update.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- falcon_configure - fixed issue with master image and provisioning tokens (https://github.com/CrowdStrike/ansible_collection_falcon/pull/546)
+- falconct_info - added support for querying provisioning tokens (https://github.com/CrowdStrike/ansible_collection_falcon/pull/546)

--- a/molecule/falcon_configure_remove_aid/converge.yml
+++ b/molecule/falcon_configure_remove_aid/converge.yml
@@ -10,6 +10,7 @@
       vars:
         falcon_option_set: yes
         falcon_cid: "{{ lookup('env', 'FALCON_CID') }}"
+        falcon_provisioning_token: "{{ lookup('env', 'FALCON_PROV_TOKEN') }}"
         falcon_tags: 'molecule,testing'
         falcon_backend: 'bpf'
         falcon_remove_aid: yes

--- a/molecule/falcon_configure_remove_aid/molecule.yml
+++ b/molecule/falcon_configure_remove_aid/molecule.yml
@@ -29,5 +29,6 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - verify
     - destroy

--- a/molecule/falcon_configure_remove_aid/molecule.yml
+++ b/molecule/falcon_configure_remove_aid/molecule.yml
@@ -29,7 +29,5 @@ scenario:
     - create
     - prepare
     - converge
-    - idempotence
-    - side_effect
     - verify
     - destroy

--- a/molecule/falcon_configure_remove_aid/verify.yml
+++ b/molecule/falcon_configure_remove_aid/verify.yml
@@ -19,3 +19,21 @@
     ansible.builtin.assert:
       that:
         - not info_verify.falconctl_info.aid
+
+  - name: Reboot system to force AID generation
+    ansible.builtin.reboot:
+
+  - name: Get new list of Falcon Sensor Options
+    crowdstrike.falcon.falconctl_info:
+    register: new_info_verify
+
+  - name: Validate a new AID is present
+    ansible.builtin.assert:
+      that:
+        - new_info_verify.falconctl_info.aid
+
+  - name: Validate CID and Tags are still present
+    ansible.builtin.assert:
+      that:
+        - new_info_verify.falconctl_info.cid
+        - new_info_verify.falconctl_info.tags

--- a/molecule/falcon_configure_remove_aid/verify.yml
+++ b/molecule/falcon_configure_remove_aid/verify.yml
@@ -13,6 +13,7 @@
     ansible.builtin.assert:
       that:
         - info_verify.falconctl_info.cid
+        - info_verify.falconctl_info.provisioning_token
         - info_verify.falconctl_info.tags
 
   - name: Verify AID is not present
@@ -23,6 +24,16 @@
   - name: Reboot system to force AID generation
     ansible.builtin.reboot:
 
+  # Wait for aid to be generated
+  - name: Wait for Falcon Sensor to Generate AID
+    crowdstrike.falcon.falconctl_info:
+      name:
+        - aid
+    register: aid_info
+    retries: 6
+    delay: 10
+    until: aid_info.falconctl_info.aid
+
   - name: Get new list of Falcon Sensor Options
     crowdstrike.falcon.falconctl_info:
     register: new_info_verify
@@ -31,6 +42,11 @@
     ansible.builtin.assert:
       that:
         - new_info_verify.falconctl_info.aid
+
+  - name: Validate Provisioning Token is not present
+    ansible.builtin.assert:
+      that:
+        - not new_info_verify.falconctl_info.provisioning_token
 
   - name: Validate CID and Tags are still present
     ansible.builtin.assert:

--- a/molecule/falcon_configure_remove_aid/verify.yml
+++ b/molecule/falcon_configure_remove_aid/verify.yml
@@ -13,7 +13,6 @@
     ansible.builtin.assert:
       that:
         - info_verify.falconctl_info.cid
-        - info_verify.falconctl_info.provisioning_token
         - info_verify.falconctl_info.tags
 
   - name: Verify AID is not present
@@ -42,11 +41,6 @@
     ansible.builtin.assert:
       that:
         - new_info_verify.falconctl_info.aid
-
-  - name: Validate Provisioning Token is not present
-    ansible.builtin.assert:
-      that:
-        - not new_info_verify.falconctl_info.provisioning_token
 
   - name: Validate CID and Tags are still present
     ansible.builtin.assert:

--- a/plugins/module_utils/falconctl_utils.py
+++ b/plugins/module_utils/falconctl_utils.py
@@ -29,7 +29,6 @@ FALCONCTL_GET_OPTIONS = [
     "message_log",
     "billing",
     "tags",
-    'provisioning_token',
     "version",
     "rfm_state",
     "rfm_reason",

--- a/plugins/module_utils/falconctl_utils.py
+++ b/plugins/module_utils/falconctl_utils.py
@@ -29,7 +29,7 @@ FALCONCTL_GET_OPTIONS = [
     "message_log",
     "billing",
     "tags",
-    # 'provisioning_token', # Taking it out since this does not seem to be a perm option
+    'provisioning_token',
     "version",
     "rfm_state",
     "rfm_reason",

--- a/plugins/modules/falconctl.py
+++ b/plugins/modules/falconctl.py
@@ -351,7 +351,7 @@ def main():  # pylint: disable=missing-function-docstring
     module_args = dict(
         state=dict(required=True, choices=["absent", "present"], type="str"),
         cid=dict(required=False, type="str"),
-        provisioning_token=dict(required=False, no_log=True, type="str"),
+        provisioning_token=dict(required=False, type="str"),
         aid=dict(required=False, type="bool"),
         apd=dict(required=False, type="str"),
         aph=dict(required=False, type="str"),

--- a/plugins/modules/falconctl.py
+++ b/plugins/modules/falconctl.py
@@ -351,7 +351,7 @@ def main():  # pylint: disable=missing-function-docstring
     module_args = dict(
         state=dict(required=True, choices=["absent", "present"], type="str"),
         cid=dict(required=False, type="str"),
-        provisioning_token=dict(required=False, type="str"),
+        provisioning_token=dict(required=False, no_log=False, type="str"),
         aid=dict(required=False, type="bool"),
         apd=dict(required=False, type="str"),
         aph=dict(required=False, type="str"),

--- a/plugins/modules/falconctl_info.py
+++ b/plugins/modules/falconctl_info.py
@@ -38,6 +38,7 @@ options:
         'message_log',
         'billing',
         'tags',
+        'provisioning_token',
         'version',
         'rfm_state',
         'rfm_reason',

--- a/plugins/modules/falconctl_info.py
+++ b/plugins/modules/falconctl_info.py
@@ -38,7 +38,6 @@ options:
         'message_log',
         'billing',
         'tags',
-        'provisioning_token',
         'version',
         'rfm_state',
         'rfm_reason',

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -40,7 +40,7 @@ falcon_client_secret:
 # Installation tokens prevent unauthorized hosts from being accidentally or maliciously added
 # to your Customer ID (CID). Installation tokens are an optional security
 # measure for your CID. For more details:
-# https://falcon.crowdstrike.com/support/documentation/20/falcon-sensor-for-linux#optional:-installing-to-a-cid-that-requires-installation-tokens
+# https://falcon.crowdstrike.com/support/documentation/page/f4d593ca/installation-options-for-falcon-sensor-for-linux#l086f14c
 #
 falcon_provisioning_token:
 

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -47,12 +47,22 @@
         - falconctl_result.changed
       # noqa no-handler
 
-    - name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
+    # Handle Master Image steps
+    - name: CrowdStrike Falcon | Master Image Prep | Removing AID
       crowdstrike.falcon.falconctl:
         aid: yes
         state: absent
       when:
         - falcon_remove_aid
+
+    - name: CrowdStrike Falcon | Master Image Prep | Set Provisioning Token (if applicable)
+      crowdstrike.falcon.falconctl:
+        cid: "{{ options.cid }}"
+        provisioning_token: "{{ options.provisioning_token }}"
+        state: present
+      when:
+        - falcon_remove_aid
+        - options.provisioning_token
 
 # Start of MacOSX Configuration
 - name: CrowdStrike Falcon | Stat Falcon Sensor (macOS)

--- a/roles/falcon_configure/tasks/remove_aid.yml
+++ b/roles/falcon_configure/tasks/remove_aid.yml
@@ -1,5 +1,5 @@
 ---
-- name: CrowdStrike Falcon | Remove Falcon Agent ID (AID) If Building A Primary Image
+- name: CrowdStrike Falcon | Remove Falcon Agent ID (AID)
   crowdstrike.falcon.falconctl:
     aid: yes
     state: absent


### PR DESCRIPTION
Fixes #534 

This pull request introduces enhancements and modifications to the Falcon configuration role and molecule testing workflows. 

Key changes include:
- The ability to ensure master images using provisioning tokens set the token after removing the AID based on discussions internally and in #534. 
- Module updates that allows for querying provisioning-token
- Updated molecule test validations to ensure a more thorough master image test

