### PR TITLE
feat(falcon_discover): allow duplicate hostnames to be listed

### DIFF
--- a/changelogs/fragments/duplicate_hosts.yml
+++ b/changelogs/fragments/duplicate_hosts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- falcon_discover - Added ability to allow duplicate hosts in the same environment (https://github.com/CrowdStrike/ansible_collection_falcon/pull/551)


### PR DESCRIPTION
Fixes #550

This PR adds a new option `allow_duplicates` that will allow the user to display all hosts with the same hostname, differentiated by Asset ID from the Discover API.

**Example:**
You have the following hosts in your environment:
- example-host1
- example-host1
If you set `allow_duplicates: true` then you will see:
- example-host1
- example-host1_fkjlajksdlfjalsdjflkjlasdjflkj_jsdljkfalkjsdlfkja