### PR TITLE
feat(eda): add ability to start stream from the latest event

### DIFF
--- a/changelogs/fragments/eda-updates.yml
+++ b/changelogs/fragments/eda-updates.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- eventsource - add support for starting stream from latest event (https://github.com/CrowdStrike/ansible_collection_falcon/pull/552)
+
+bugfixes:
+- eventsource - fix issue with refreshinterval causing timeout (https://github.com/CrowdStrike/ansible_collection_falcon/pull/552)

--- a/docs/crowdstrike.falcon.eventstream.md
+++ b/docs/crowdstrike.falcon.eventstream.md
@@ -23,7 +23,8 @@ An ansible-rulebook event source plugin for generating events from the Falcon Ev
 | **stream_name**</br><font color=purple>string</font> | Label that identifies your connection.</br>**Max:** 32 alphanumeric characters (a-z, A-Z, 0-9)</br><font color=blue>**Default:** eda</font> |
 | **include_event_types**</br><font color=purple>list</font> | List of event types to include. Otherwise all event types are included.</br>Refer to the [Streaming API Event Dictionary](https://falcon.crowdstrike.com/documentation/62/streaming-api-event-dictionary).</br><font color=blue>**Default:** None.</font> |
 | **exclude_event_types**</br><font color=purple>list</font> | List of event types to exclude.</br>Refer to the [Streaming API Event Dictionary](https://falcon.crowdstrike.com/documentation/62/streaming-api-event-dictionary).</br><font color=blue>**Default:** None.</font> |
-| **offset**</br><font color=purple>int</font> | The offset to start streaming from.</br><font color=blue>**Default:** 0.</font> |
+| **offset**</br><font color=purple>int</font> | The offset to start streaming from. The default (0) is to begin the stream from the start of all events.</br>*This option is mutually exclusive with* `latest`.</br><font color=blue>**Default:** 0.</font> |
+| **latest**</br><font color=purple>bool</font> | Start the stream from the newest/latest event.</br>*This option is mutually exclusive with* `offset`.</br><font color=blue>**Default:** false.</font> |
 | **delay**</br><font color=purple>float</font> | Introduce a delay between each event.</br><font color=blue>**Default:** 0.</font> |
 
 ## Example Rulebook

--- a/docs/crowdstrike.falcon.eventstream.md
+++ b/docs/crowdstrike.falcon.eventstream.md
@@ -23,8 +23,8 @@ An ansible-rulebook event source plugin for generating events from the Falcon Ev
 | **stream_name**</br><font color=purple>string</font> | Label that identifies your connection.</br>**Max:** 32 alphanumeric characters (a-z, A-Z, 0-9)</br><font color=blue>**Default:** eda</font> |
 | **include_event_types**</br><font color=purple>list</font> | List of event types to include. Otherwise all event types are included.</br>Refer to the [Streaming API Event Dictionary](https://falcon.crowdstrike.com/documentation/62/streaming-api-event-dictionary).</br><font color=blue>**Default:** None.</font> |
 | **exclude_event_types**</br><font color=purple>list</font> | List of event types to exclude.</br>Refer to the [Streaming API Event Dictionary](https://falcon.crowdstrike.com/documentation/62/streaming-api-event-dictionary).</br><font color=blue>**Default:** None.</font> |
-| **offset**</br><font color=purple>int</font> | The offset to start streaming from. The default (0) is to begin the stream from the start of all events.</br>*This option is mutually exclusive with* `latest`.</br><font color=blue>**Default:** 0.</font> |
-| **latest**</br><font color=purple>bool</font> | Start the stream from the newest/latest event.</br>*This option is mutually exclusive with* `offset`.</br><font color=blue>**Default:** false.</font> |
+| **offset**</br><font color=purple>int</font> | Specifies where in the event stream you want to being processing. This is useful if you have a mechanism to track the latest offset processed.</br>*This option is mutually exclusive with* `latest`. </br><font color=blue>**Default:** None.</font> |
+| **latest**</br><font color=purple>bool</font> | Start the stream from the latest event. By default, if `offset` is not set, the stream will start from the beginning of all events.</br>*This option is mutually exclusive with* `offset`.</br><font color=blue>**Default:** false.</font> |
 | **delay**</br><font color=purple>float</font> | Introduce a delay between each event.</br><font color=blue>**Default:** 0.</font> |
 
 ## Example Rulebook
@@ -38,7 +38,8 @@ An ansible-rulebook event source plugin for generating events from the Falcon Ev
         falcon_client_id: "{{ FALCON_CLIENT_ID }}"
         falcon_client_secret: "{{ FALCON_CLIENT_SECRET }}"
         falcon_cloud: "us-2"
-        # offset: 12345
+        # start stream from specified offset
+        offset: 12345
         stream_name: "eda-example"
         include_event_types:
           - "DetectionSummaryEvent"

--- a/extensions/eda/plugins/event_source/eventstream.py
+++ b/extensions/eda/plugins/event_source/eventstream.py
@@ -258,10 +258,10 @@ class Stream:
         """
         logger.info("Initializing Stream: %s", stream_name)
         self.client: AIOFalconAPI = client
+        self.session: aiohttp.ClientSession = client.session
         self.stream_name: str = stream_name
         self.data_feed: str = stream["dataFeedURL"]
         self.token: str = stream["sessionToken"]["token"]
-        self.token_expires: str = stream["sessionToken"]["expiration"]
         self.refresh_url: str = stream["refreshActiveSessionURL"]
         self.partition: str = re.findall(r"v1/(\d+)", self.refresh_url)[0]
         self.offset: int = offset
@@ -335,11 +335,10 @@ class Stream:
                 "Authorization": f"Token {self.token}",
             },
             "raise_for_status": True,
-            "timeout": aiohttp.ClientTimeout(total=float(self.refresh_interval) + 30),
+            "timeout": aiohttp.ClientTimeout(total=None),
         }
 
-        session = aiohttp.ClientSession()
-        self.spigot: aiohttp.ClientResponse = await session.get(**kwargs)
+        self.spigot: aiohttp.ClientResponse = await self.session.get(**kwargs)
         logger.info(
             "Successfully opened stream %s:%s",
             self.stream_name,

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 [testenv:ruff]
 deps = ruff
 commands =
-    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501 -q extensions/eda/plugins'
+    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501,FBT001,C901 -q extensions/eda/plugins'
 
 [testenv:darglint]
 deps = darglint


### PR DESCRIPTION
Fixes #526 
Fixes #549 

This option is mutually exclusive with offset, and if selected, will allow the event stream to always start from the latest event. This is useful for not having to manage the offset.

This PR also fixes some issues with handling timeout due to refresh interval. 