### PR TITLE
feat(info modules): enhance pagination and remove limits

### DIFF
--- a/changelogs/fragments/info-updates.yml
+++ b/changelogs/fragments/info-updates.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Enhance the info modules with how pagination is handled and clean options (https://github.com/CrowdStrike/ansible_collection_falcon/pull/558)

--- a/plugins/module_utils/falconpy_utils.py
+++ b/plugins/module_utils/falconpy_utils.py
@@ -117,29 +117,29 @@ def handle_return_errors(module, result, query_result):
             module.fail_json(msg=msg, **result)
 
 
-def get_paginated_results_info(module, qfilter, limit, method):
+def get_paginated_results_info(module, args, limit, method, list_name):
     """Return paginated results from the Falcon API for info modules."""
     result = dict(
         changed=False,
-        info=[],
+        **{list_name: []},
     )
 
     max_limit = limit
     offset = None
     running = True
     while running:
-        query_result = method(filter=qfilter, offset=offset, limit=max_limit)
+        query_result = method(**args, offset=offset, limit=max_limit)
         if query_result["status_code"] != 200:
             handle_return_errors(module, result, query_result)
 
         if query_result["body"]["resources"]:
-            result["info"].extend(query_result["body"]["resources"])
+            result[list_name].extend(query_result["body"]["resources"])
         else:
             return result
 
         # Check if we need to continue
         offset = query_result["body"]["meta"]["pagination"]["offset"]
-        if query_result["body"]["meta"]["pagination"]["total"] <= len(result["info"]):
+        if query_result["body"]["meta"]["pagination"]["total"] <= len(result[list_name]):
             running = False
 
     return result

--- a/plugins/modules/kernel_support_info.py
+++ b/plugins/modules/kernel_support_info.py
@@ -199,12 +199,22 @@ def main():
 
     check_falconpy_version(module)
 
-    query_filter = module.params.get("filter")
+    args = {}
+    for key, value in module.params.items():
+        if key in POLICY_ARGS:
+            args[key] = value
+
     max_limit = 500
 
     falcon = authenticate(module, SensorUpdatePolicy)
 
-    result = get_paginated_results_info(module, query_filter, max_limit, falcon.query_combined_kernels)
+    result = get_paginated_results_info(
+        module,
+        args,
+        max_limit,
+        falcon.query_combined_kernels,
+        list_name="info"
+    )
 
     module.exit_json(**result)
 

--- a/plugins/modules/sensor_download_info.py
+++ b/plugins/modules/sensor_download_info.py
@@ -25,11 +25,6 @@ options:
       - The filter expression that should be used to limit the results using FQL (Falcon Query Language) syntax.
       - See the return values or CrowdStrike docs for more information about the available filters that can be used.
     type: str
-  limit:
-    description:
-      - The maximum number of records to return. [1-500]
-    default: 100
-    type: int
 
 extends_documentation_fragment:
   - crowdstrike.falcon.credentials
@@ -44,14 +39,12 @@ author:
 """
 
 EXAMPLES = r"""
-- name: Get a list of all Linux Sensor Installers
+- name: Get all Linux Sensor Installers
   crowdstrike.falcon.sensor_download_info:
     filter: "platform:'linux'"
-    limit: 200
 
-- name: Get a list of the 2 latest Windows Sensor Installers
+- name: Get all Windows Sensor Installers sorted by version
   crowdstrike.falcon.sensor_download_info:
-    limit: 2
     filter: "platform:'windows'"
     sort: "version|desc"
 
@@ -150,7 +143,6 @@ except ImportError:
 
 DOWNLOAD_INFO_ARGS = {
     "filter": {"type": "str", "required": False},
-    "limit": {"type": "int", "required": False, "default": 100},
     "sort": {"type": "str", "required": False},
 }
 
@@ -184,6 +176,7 @@ def main():
 
     falcon = authenticate(module, SensorDownload)
 
+    # Pagination is not supported, so we can just call the API directly
     query_result = falcon.override("GET", "/sensors/combined/installers/v2", parameters={**args})
 
     result = dict(


### PR DESCRIPTION
Closes #556

Limits are not consistent within our APIs to offer them modularly. Instead, you can use native Ansible to further refine and limit the info modules as needed.