### PR TITLE
feat: add toggle for become on windows

### DIFF
--- a/changelogs/fragments/toggle-win-become.yml
+++ b/changelogs/fragments/toggle-win-become.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- allow become clause for Windows tasks to be toggable in each role (https://github.com/CrowdStrike/ansible_collection_falcon/pull/561)

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -36,6 +36,7 @@ sensor to be installed prior to running this role.
 
 ### Windows Specific Variables
 
+- `falcon_windows_become` - Whether to become a privileged user on Windows (bool, default: ***true***)
 - `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
 - `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: ***SYSTEM***)
 

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -114,6 +114,11 @@ falcon_tags:
 #
 falcon_backend:
 
+# Ansible become toggle for Windows systems.
+# The default is true
+#
+falcon_windows_become: true
+
 # Ansible become method for Windows systems.
 # The default is runas
 #

--- a/roles/falcon_configure/tasks/main.yml
+++ b/roles/falcon_configure/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: Windows block
   when:
     - ansible_facts['os_family'] == "Windows"
-  become: true
+  become: "{{ falcon_windows_become }}"
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"
   block:

--- a/roles/falcon_install/README.md
+++ b/roles/falcon_install/README.md
@@ -73,6 +73,7 @@ The following variables are currently supported:
 - `falcon_windows_tmp_dir` - Temporary Windows installation directory for the Falson Sensor (string, default: ***%SYSTEMROOT%\\Temp***)
 - `falcon_windows_install_args` - Additional Windows install arguments (string, default: ***/norestart***)
 - `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: ***/norestart***)
+- `falcon_windows_become` - Whether to become a privileged user on Windows (bool, default: ***true***)
 - `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
 - `falcon_windows_become_user` - The privileged user to install the sensor on Windows (string, default: ***SYSTEM***)
 
@@ -182,6 +183,7 @@ This example installs and configures the Falcon Sensor on Windows:
       falcon_client_secret: <FALCON_CLIENT_SECRET>
       falcon_cid: <FALCON_CID>
       falcon_windows_install_args: "/norestart ProvWaitTime=600"
+      falcon_windows_become: true
       falcon_windows_become_method: runas
       falcon_windows_become_user: SYSTEM
 ```

--- a/roles/falcon_install/defaults/main.yml
+++ b/roles/falcon_install/defaults/main.yml
@@ -174,6 +174,11 @@ falcon_windows_install_args: "/norestart"
 #
 falcon_windows_uninstall_args: "/norestart"
 
+# Ansible become toggle for Windows systems.
+# The default is true
+#
+falcon_windows_become: true
+
 # Ansible become method for Windows systems.
 # The default is runas
 #

--- a/roles/falcon_install/tasks/main.yml
+++ b/roles/falcon_install/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: Install block (windows)
   when:
     - ansible_facts['os_family'] == "Windows"
-  become: true
+  become: "{{ falcon_windows_become }}"
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"
   block:

--- a/roles/falcon_uninstall/README.md
+++ b/roles/falcon_uninstall/README.md
@@ -27,6 +27,7 @@ This role uninstalls the CrowdStrike Falcon Sensor.
 ### Windows Specific Variables
 
 - `falcon_windows_uninstall_args` - Additional Windows uninstall arguments (string, default: ***/norestart***)
+- `falcon_windows_become` - Whether to become a privileged user on Windows (bool, default: ***true***)
 - `falcon_windows_become_method` - The way to become a privileged user on Windows (string, default: ***runas***)
 - `falcon_windows_become_user` - The privileged user to uninstall the sensor on Windows (string, default: ***SYSTEM***)
 

--- a/roles/falcon_uninstall/defaults/main.yml
+++ b/roles/falcon_uninstall/defaults/main.yml
@@ -34,6 +34,11 @@ falcon_remove_host: false
 #
 falcon_windows_uninstall_args: "/norestart"
 
+# Ansible become toggle for Windows systems.
+# The default is true
+#
+falcon_windows_become: true
+
 # Ansible become method for Windows systems.
 # The default is runas
 #

--- a/roles/falcon_uninstall/tasks/main.yml
+++ b/roles/falcon_uninstall/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Windows Block
   when:
     - ansible_facts['os_family'] == "Windows"
-  become: true
+  become: "{{ falcon_windows_become }}"
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"
   block:

--- a/roles/falcon_uninstall/tasks/remove_host_pretasks.yml
+++ b/roles/falcon_uninstall/tasks/remove_host_pretasks.yml
@@ -27,7 +27,7 @@
 - name: "CrowdStrike Falcon | Windows AID Block"
   when:
     - ansible_facts['os_family'] == "Windows"
-  become: true
+  become: "{{ falcon_windows_become }}"
   become_method: "{{ falcon_windows_become_method }}"
   become_user: "{{ falcon_windows_become_user }}"
   block:


### PR DESCRIPTION
This PR adds a new variable `falcon_windows_become` to the install, configure, and uninstall roles so that privilege escalation may be disabled if necessary.

Depending on how a Windows machine is configured and which user is used, becoming another user may be unnecessary.