### PR TITLE
fix(falcon_configure): this task should only run when both are set

### DIFF
--- a/changelogs/fragments/fix-truthy-564.yml
+++ b/changelogs/fragments/fix-truthy-564.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- falcon_configure - Fix truthy condition for falcon_cid and falcon_provisioning_token (https://github.com/CrowdStrike/ansible_collection_falcon/pull/565)

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -62,7 +62,8 @@
         state: present
       when:
         - falcon_remove_aid
-        - options.provisioning_token
+        - options.cid | bool
+        - options.provisioning_token | bool
 
 # Start of MacOSX Configuration
 - name: CrowdStrike Falcon | Stat Falcon Sensor (macOS)


### PR DESCRIPTION
Fixes #564 
There was an issue when the cid options was set to "" for it be deleted, and then it would get to this point and fail because the when clause was incorrect. A simple truthy test should provide us what we are looking for since we allow empty strings to be passed in to options for deletion purposes. 

Also added options.cid to this since it makes sense we would want to ensure both are set to use this task.