### PR TITLE
fix(falcon_install): fixes issue with deleting sensor when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 /.vscode
 html/
 ansible.cfg
+Vagrantfile
+.vagrant/

--- a/changelogs/fragments/578-localhost-deletion.yml
+++ b/changelogs/fragments/578-localhost-deletion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_install - fixes issue with premature localhost deletion of downloaded sensor (https://github.com/CrowdStrike/ansible_collection_falcon/pull/584)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -98,17 +98,6 @@
   register: win_falcon_sensor_copied
   when: ansible_os_family == "Windows"
 
-- name: CrowdStrike Falcon | Remove Downloaded Sensor Installation directory (local)
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  changed_when: false
-  delegate_to: localhost
-  loop:
-    - "{{ falcon_sensor_download.path }}"
-    - "{{ falcon_sensor_download.path + '.lock' }}"
-  when: falcon_api_sensor_download_cleanup
-
 - name: CrowdStrike Falcon | Set full file download path (non-windows)
   ansible.builtin.set_fact:
     falcon_sensor_pkg: "{{ falcon_sensor_copied.dest }}"

--- a/roles/falcon_install/tasks/cleanup.yml
+++ b/roles/falcon_install/tasks/cleanup.yml
@@ -1,0 +1,10 @@
+- name: CrowdStrike Falcon | Remove Downloaded Sensor Installation directory (local)
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  changed_when: false
+  delegate_to: localhost
+  loop:
+    - "{{ falcon_sensor_download.path }}"
+    - "{{ falcon_sensor_download.path + '.lock' }}"
+  when: falcon_api_sensor_download_cleanup

--- a/roles/falcon_install/tasks/main.yml
+++ b/roles/falcon_install/tasks/main.yml
@@ -50,3 +50,10 @@
   block:
     - ansible.builtin.include_tasks: win_install.yml
       # noqa name[missing]
+
+- name: Cleanup block
+  when:
+    - falcon_install_method == "api"
+  block:
+    - ansible.builtin.include_tasks: cleanup.yml
+    # noqa name[missing]


### PR DESCRIPTION
Fixes #578

This PR addresses the issue of prematurely deleting the downloaded sensor file prior to installation. We have removed the logic to it's own task file that runs at the end of the play.