### PR TITLE
fix(falcon_configure): fixes issue with unwarranted bool (master image)

### DIFF
--- a/changelogs/fragments/579-fix-image-prep.yml
+++ b/changelogs/fragments/579-fix-image-prep.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_configure - Fixed issue where the bool filter was incorrectly used with provisioning token when clause for master image prep (https://github.com/CrowdStrike/ansible_collection_falcon/pull/585)

--- a/molecule/falcon_configure_remove_aid/verify.yml
+++ b/molecule/falcon_configure_remove_aid/verify.yml
@@ -20,6 +20,16 @@
       that:
         - not info_verify.falconctl_info.aid
 
+  - name: Register provisioning token output
+    ansible.builtin.command:
+      cmd: /opt/CrowdStrike/falconctl -g --provisioning-token
+    register: provisioning_token
+
+  - name: Verify provisioning token is present
+    ansible.builtin.assert:
+      that:
+        - "'not set' not in provisioning_token.stdout"
+
   - name: Reboot system to force AID generation
     ansible.builtin.reboot:
 

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -58,11 +58,11 @@
     - name: CrowdStrike Falcon | Master Image Prep | Set Provisioning Token (if applicable)
       crowdstrike.falcon.falconctl:
         cid: "{{ options.cid }}"
-        provisioning_token: "{{ options.provisioning_token }}"
+        provisioning_token: "{{ falcon_provisioning_token }}"
         state: present
       when:
         - falcon_remove_aid
-        - options.provisioning_token is defined and options.provisioning_token | length > 0
+        - falcon_provisioning_token is not none and falcon_provisioning_token | length > 0
 
     - name: CrowdStrike Falcon | Master Image Prep | Stop Falcon Sensor service
       ansible.builtin.service:

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -62,8 +62,14 @@
         state: present
       when:
         - falcon_remove_aid
-        - options.cid | bool
-        - options.provisioning_token | bool
+        - options.provisioning_token is defined and options.provisioning_token | length > 0
+
+    - name: CrowdStrike Falcon | Master Image Prep | Stop Falcon Sensor service
+      ansible.builtin.service:
+        name: falcon-sensor
+        state: stopped
+      when:
+        - falcon_remove_aid
 
 # Start of MacOSX Configuration
 - name: CrowdStrike Falcon | Stat Falcon Sensor (macOS)


### PR DESCRIPTION
Fixes #579

This PR introduces a fix to incorrectly using the |bool filter when working with prov tokens in master image prep. Also adding the ability to stop the sensor when working within a master image prep as to prevent the sensor from potentially updating/restarting via that cloud updates.