### PR TITLE
fix(falcon_configure): control aid generation wait time and logic

### DIFF
--- a/changelogs/fragments/583-aid-retry.yml
+++ b/changelogs/fragments/583-aid-retry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_configure - fix issue where AID generation task would fail/timeout (https://github.com/CrowdStrike/ansible_collection_falcon/pull/586)

--- a/roles/falcon_configure/README.md
+++ b/roles/falcon_configure/README.md
@@ -32,6 +32,15 @@ Configures the CrowdStrike Falcon Sensor. This role is focused mainly on configu
 
 - `falcon_remove_aid` - Remove the Falcon Agent ID (AID) (bool, default: ***null***)
 
+### Linux Specific Variables
+
+- `falcon_aid_retries` - Number of retries to attempt when waiting to retrieve the Falcon Agent ID (AID) (int, default: ***6***)
+- `falcon_aid_delay` - Number of seconds to wait between `falcon_aid_retries` when waiting to retrieve the Falcon Agent ID (AID) (int, default: ***10***)
+
+> These variables control the retry behavior when attempting to retrieve the Falcon Agent ID (AID) after configuring
+> and restarting the sensor. The default values should work for most, but you may need to increase them in
+> environments with slower startup times.
+
 ### Windows Specific Variables
 
 - `falcon_windows_become` - Whether to become a privileged user on Windows (bool, default: ***true***)

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -44,6 +44,16 @@ falcon_client_secret:
 #
 falcon_provisioning_token:
 
+######### Wait for AID generation #########
+# Number of retries to attempt when waiting to retrieve the Falcon Agent ID (AID)
+# after sensor restart.
+falcon_aid_retries: 6
+
+# Number of seconds to wait between retries when waiting to retrieve the Falcon Agent ID (AID)
+# after sensor restart.
+falcon_aid_delay: 10
+###########################################
+
 # Falcon requires that a master image remove the Falcon Agent ID (AID). This
 # ensures instances spun up from the master receive their own, unique,
 # Falcon Agent ID.

--- a/roles/falcon_configure/defaults/main.yml
+++ b/roles/falcon_configure/defaults/main.yml
@@ -47,7 +47,7 @@ falcon_provisioning_token:
 ######### Wait for AID generation #########
 # Number of retries to attempt when waiting to retrieve the Falcon Agent ID (AID)
 # after sensor restart.
-falcon_aid_retries: 6
+falcon_aid_retries: 12
 
 # Number of seconds to wait between retries when waiting to retrieve the Falcon Agent ID (AID)
 # after sensor restart.

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -33,19 +33,44 @@
       # noqa args[module]
       # noqa no-handler
 
-    # Wait for aid to be generated
-    - name: CrowdStrike Falcon | Wait for Falcon Sensor to Generate AID
-      crowdstrike.falcon.falconctl_info:
-        name:
-          - aid
-      register: info
-      retries: 6
-      delay: 10
-      until: info.falconctl_info.aid
+    - name: Wait for AID to be generated block
       when:
         - info.falconctl_info.cid
         - falconctl_result.changed
-      # noqa no-handler
+      block:
+        # Wait for aid to be generated
+        - name: CrowdStrike Falcon | Wait for Falcon Sensor to Generate AID
+          crowdstrike.falcon.falconctl_info:
+            name:
+              - aid
+          register: get_aid
+          retries: "{{ falcon_aid_retries | int }}"
+          delay: "{{ falcon_aid_delay | int }}"
+          until: get_aid.falconctl_info.aid
+
+      rescue:
+        - name: CrowdStrike Falcon | Second attempt to get AID
+          crowdstrike.falcon.falconctl_info:
+            name:
+              - aid
+          register: get_aid_retry
+          retries: "{{ falcon_aid_retries | int }}"
+          delay: "{{ falcon_aid_delay | int }}"
+          until: get_aid_retry.falconctl_info.aid
+          ignore_errors: true
+
+        - name: CrowdStrike Falcon | Fail if AID Generation Fails
+          ansible.builtin.fail:
+            msg: "{{ error_msg }}"
+          vars:
+            error_msg:
+              error: "Failed to generate Falcon Sensor AID after multiple attempts."
+              troubleshooting_steps:
+                - "Verify the sensor is properly installed"
+                - "Confirm the CID is correct"
+                - "Check system can reach the CrowdStrike cloud"
+                - "Manually verify AID with: sudo /opt/CrowdStrike/falconctl -g --aid"
+          when: not get_aid_retry.falconctl_info.aid
 
     # Handle Master Image steps
     - name: CrowdStrike Falcon | Master Image Prep | Removing AID

--- a/roles/falcon_configure/tasks/configure.yml
+++ b/roles/falcon_configure/tasks/configure.yml
@@ -33,44 +33,18 @@
       # noqa args[module]
       # noqa no-handler
 
-    - name: Wait for AID to be generated block
+    # Wait for aid to be generated
+    - name: CrowdStrike Falcon | Wait for Falcon Sensor to Generate AID
+      crowdstrike.falcon.falconctl_info:
+        name:
+          - aid
+      register: get_aid
+      retries: "{{ falcon_aid_retries | int }}"
+      delay: "{{ falcon_aid_delay | int }}"
+      until: get_aid.falconctl_info.aid
       when:
         - info.falconctl_info.cid
         - falconctl_result.changed
-      block:
-        # Wait for aid to be generated
-        - name: CrowdStrike Falcon | Wait for Falcon Sensor to Generate AID
-          crowdstrike.falcon.falconctl_info:
-            name:
-              - aid
-          register: get_aid
-          retries: "{{ falcon_aid_retries | int }}"
-          delay: "{{ falcon_aid_delay | int }}"
-          until: get_aid.falconctl_info.aid
-
-      rescue:
-        - name: CrowdStrike Falcon | Second attempt to get AID
-          crowdstrike.falcon.falconctl_info:
-            name:
-              - aid
-          register: get_aid_retry
-          retries: "{{ falcon_aid_retries | int }}"
-          delay: "{{ falcon_aid_delay | int }}"
-          until: get_aid_retry.falconctl_info.aid
-          ignore_errors: true
-
-        - name: CrowdStrike Falcon | Fail if AID Generation Fails
-          ansible.builtin.fail:
-            msg: "{{ error_msg }}"
-          vars:
-            error_msg:
-              error: "Failed to generate Falcon Sensor AID after multiple attempts."
-              troubleshooting_steps:
-                - "Verify the sensor is properly installed"
-                - "Confirm the CID is correct"
-                - "Check system can reach the CrowdStrike cloud"
-                - "Manually verify AID with: sudo /opt/CrowdStrike/falconctl -g --aid"
-          when: not get_aid_retry.falconctl_info.aid
 
     # Handle Master Image steps
     - name: CrowdStrike Falcon | Master Image Prep | Removing AID


### PR DESCRIPTION
Fixes #583

This PR should address concerns about potential timeouts or "misfires" around waiting for an AID to be generated on Linux systems (particularly on Ubuntu 20.04). We've added the following to help mitigate these issues:
1. Use variables to control the retries/delays. Default to 120 seconds (12/10).