### PR TITLE
fix(falcon_install): improves error message when using falcon_sensor_version_decrement but not enough historical sensors are available

### DIFF
--- a/changelogs/fragments/577-decrement.yml
+++ b/changelogs/fragments/577-decrement.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - falcon_install - fixes issue where failure to download sensor weren't apparent (https://github.com/CrowdStrike/ansible_collection_falcon/pull/588)
+  - falcon_install - improves error message when using falcon_sensor_version_decrement but not enough historical sensors are available (https://github.com/CrowdStrike/ansible_collection_falcon/pull/588)

--- a/changelogs/fragments/577-decrement.yml
+++ b/changelogs/fragments/577-decrement.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - falcon_install - fixes issue where failure to download sensor weren't apparent (https://github.com/CrowdStrike/ansible_collection_falcon/pull/588)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -54,10 +54,22 @@
   register: falcon_api_installer_list
   delegate_to: localhost
 
-- name: CrowdStrike Falcon | Validate Sensor request
+- name: CrowdStrike Falcon | Validate sensor request
   ansible.builtin.fail:
-    msg: "No Falcon Sensor was found! If passing in falcon_sensor_version, ensure it is correct!"
+    msg: "No Falcon sensor was found! If passing in falcon_sensor_version, ensure it is correct!"
   when: falcon_api_installer_list.installers[0] is not defined
+
+- name: CrowdStrike Falcon | Validate available sensor count > decrement (if applicable)
+  ansible.builtin.assert:
+    that:
+      - falcon_api_installer_list.installers | length > falcon_sensor_version_decrement
+    fail_msg:
+      "Not enough sensor versions available for the specified decrement value: N-{{ falcon_sensor_version_decrement }}.
+      This may occur if your OS distribution/version is newly supported and fewer
+      historical sensor versions exist."
+  when:
+    - falcon_sensor_version_decrement is defined
+    - falcon_sensor_version_decrement > 0
 
 - name: CrowdStrike Falcon | Ensure download path exists (local)
   ansible.builtin.file:


### PR DESCRIPTION
Fixes #577

This PR adds better failure message when a user uses falcon_sensor_version_decrement on newly supported linux OS's. Before, it would just fail when trying to download a sensor with an incorrect list index value.