### PR TITLE
feat: new intel rule modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Name | Description
 [crowdstrike.falcon.host_contain](https://crowdstrike.github.io/ansible_collection_falcon/host_contain_module.html)|Network contain hosts in Falcon
 [crowdstrike.falcon.host_hide](https://crowdstrike.github.io/ansible_collection_falcon/host_hide_module.html)|Hide/Unhide hosts from the Falcon console. Preference should be given to using `Host Retention Policies` under `Host Management` in the Falcon console which provides more flexibility and customization for automatically hiding and deleting hosts instead.
 [crowdstrike.falcon.host_info](https://crowdstrike.github.io/ansible_collection_falcon/host_info_module.html)|Get information about Falcon hosts
+[crowdstrike.falcon.intel_rule_download](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_download_module.html)|Download CrowdStrike Falcon Intel rule files
 [crowdstrike.falcon.intel_rule_info](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_info_module.html)|Get information about CrowdStrike Falcon Intel rules
 [crowdstrike.falcon.kernel_support_info](https://crowdstrike.github.io/ansible_collection_falcon/kernel_support_info_module.html)|Get information about kernels supported by the Falcon Sensor for Linux
 [crowdstrike.falcon.sensor_download](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_module.html)|Download Falcon Sensor Installer

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Name | Description
 [crowdstrike.falcon.host_contain](https://crowdstrike.github.io/ansible_collection_falcon/host_contain_module.html)|Network contain hosts in Falcon
 [crowdstrike.falcon.host_hide](https://crowdstrike.github.io/ansible_collection_falcon/host_hide_module.html)|Hide/Unhide hosts from the Falcon console. Preference should be given to using `Host Retention Policies` under `Host Management` in the Falcon console which provides more flexibility and customization for automatically hiding and deleting hosts instead.
 [crowdstrike.falcon.host_info](https://crowdstrike.github.io/ansible_collection_falcon/host_info_module.html)|Get information about Falcon hosts
+[crowdstrike.falcon.intel_rule_info](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_info_module.html)|Get information about CrowdStrike Falcon Intel rules
 [crowdstrike.falcon.kernel_support_info](https://crowdstrike.github.io/ansible_collection_falcon/kernel_support_info_module.html)|Get information about kernels supported by the Falcon Sensor for Linux
 [crowdstrike.falcon.sensor_download](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_module.html)|Download Falcon Sensor Installer
 [crowdstrike.falcon.sensor_download_info](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_info_module.html)|Get information about Falcon Sensor Installers

--- a/changelogs/fragments/602-add-new-intel-rule.yml
+++ b/changelogs/fragments/602-add-new-intel-rule.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- intel_rule_info - added new info module for Intel Rules files (https://github.com/CrowdStrike/ansible_collection_falcon/issues/587)
+- intel_rule_download - added new module to download Intel Rules files (https://github.com/CrowdStrike/ansible_collection_falcon/issues/587)

--- a/plugins/modules/intel_rule_download.py
+++ b/plugins/modules/intel_rule_download.py
@@ -1,0 +1,406 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: intel_rule_download
+
+short_description: Download CrowdStrike Falcon Intel rule files
+
+description:
+  - Downloads CrowdStrike Falcon Intel rule files (YARA, Snort, etc.).
+  - By default, downloads the latest rule file for the specified type.
+  - Can also download a specific rule file when provided with a C(rule_id).
+
+options:
+  type:
+    description:
+      - The rule news report type.
+      - Required when C(rule_id) is not provided.
+      - Used to fetch the latest rule file of this type when C(rule_id) is not specified.
+    type: str
+    choices:
+      - common-event-format
+      - netwitness
+      - snort-suricata-changelog
+      - snort-suricata-master
+      - snort-suricata-update
+      - yara-changelog
+      - yara-master
+      - yara-update
+      - cql-master
+      - cql-changelog
+      - cql-update
+  rule_id:
+    description:
+      - The ID of a specific rule to download.
+      - If provided, the type parameter is ignored.
+    type: str
+  format:
+    description:
+      - The format of the rule file to download.
+    type: str
+    choices:
+      - zip
+      - gzip
+    default: zip
+  dest:
+    description:
+      - The directory path to save the rule file.
+      - If not specified, a temporary directory will be created using
+        the system's default temporary directory.
+    type: path
+  name:
+    description:
+      - The filename to save the rule file as.
+      - If not specified, it will use the name provided by the API.
+    type: str
+
+extends_documentation_fragment:
+  - files
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+notes:
+  - This module implements file locking to ensure safe concurrent downloads by preventing multiple
+    instances from accessing the same file simultaneously.
+  - When downloading the latest rule file without specifying a C(rule_id), the module will automatically
+    query for the most recent rule of the specified type.
+
+requirements:
+  - Rules (Falcon Intelligence) [B(READ)] API scope
+
+author:
+  - CrowdStrike (@crowdstrike)
+"""
+
+EXAMPLES = r"""
+- name: Download the latest YARA master rule file
+  crowdstrike.falcon.intel_rule_download:
+    type: "yara-master"
+    dest: "/tmp/rules"
+
+- name: Download a specific rule file by ID
+  crowdstrike.falcon.intel_rule_download:
+    rule_id: "1234567890"
+    dest: "/tmp/rules"
+    name: "custom_rule.zip"
+
+- name: Download the latest Snort rule file in gzip format
+  crowdstrike.falcon.intel_rule_download:
+    type: "snort-suricata-master"
+    format: "gzip"
+    dest: "/tmp/rules"
+"""
+
+RETURN = r"""
+path:
+  description: The full path of the downloaded rule file.
+  returned: success
+  type: str
+  sample: /tmp/rules/yara-master-20231015.zip
+rule_id:
+  description: The ID of the downloaded rule.
+  returned: success
+  type: str
+  sample: "1234567890"
+rule_name:
+  description: The name of the downloaded rule.
+  returned: success
+  type: str
+  sample: "CrowdStrike Intelligence Feed: YARA Master - 2023/10/15"
+rule_type:
+  description: The type of the downloaded rule.
+  returned: success
+  type: str
+  sample: "yara-master"
+"""
+
+import errno
+import fcntl
+import traceback
+import os
+import time
+import random
+from tempfile import mkdtemp
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import Intel
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(
+        type=dict(
+            type='str',
+            choices=[
+                'common-event-format',
+                'netwitness',
+                'snort-suricata-changelog',
+                'snort-suricata-master',
+                'snort-suricata-update',
+                'yara-changelog',
+                'yara-master',
+                'yara-update',
+                'cql-master',
+                'cql-changelog',
+                'cql-update'
+            ]
+        ),
+        rule_id=dict(type='str'),
+        format=dict(
+            type='str',
+            choices=['zip', 'gzip'],
+            default='zip'
+        ),
+        dest=dict(type='path'),
+        name=dict(type='str'),
+    )
+    return args
+
+
+def lock_file(file_path, exclusive=True, timeout=300, retry_interval=5):
+    """Lock a file for reading or writing."""
+    lock_file_path = file_path + ".lock"
+    # Ignore the pylint warning here as a with block will close the file handle immediately
+    # and we need to keep it open to maintain the lock
+    lock_file_handle = open(lock_file_path, 'w', encoding='utf-8')  # pylint: disable=consider-using-with
+    start_time = time.time()
+    # Implement a delay to prevent thundering herd
+    delay = random.random()  # nosec
+
+    while True:
+        try:
+            if exclusive:
+                fcntl.flock(lock_file_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            else:
+                fcntl.flock(lock_file_handle, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            return lock_file_handle
+        except IOError as e:
+            if e.errno != errno.EAGAIN:
+                raise
+            if time.time() - start_time > timeout:
+                return None
+            time.sleep(delay + retry_interval)
+            delay = 0
+
+
+def unlock_file(locked_file):
+    """Unlock a file and remove the lock file."""
+    lock_path = locked_file.name  # Get the path of the lock file
+    fcntl.flock(locked_file, fcntl.LOCK_UN)
+    locked_file.close()
+
+    # Remove the lock file
+    try:
+        os.unlink(lock_path)
+    except (OSError, IOError):
+        # Don't fail if we can't remove the lock file
+        pass
+
+
+def check_destination_path(module, dest):
+    """Check if the destination path is valid."""
+    if not os.path.isdir(dest):
+        module.fail_json(msg=f"Destination path does not exist or is not a directory: {dest}")
+
+    if not os.access(dest, os.W_OK):
+        module.fail_json(msg=f"Destination path is not writable: {dest}")
+
+
+def update_permissions(module, changed, path):
+    """Update the permissions on the file if needed."""
+    file_args = module.load_file_common_arguments(module.params, path=path)
+
+    return module.set_fs_attributes_if_different(file_args, changed=changed)
+
+
+def get_latest_rule_id(module, falcon, rule_type, result):
+    """Get the latest rule ID for the specified type."""
+    query_params = {
+        'type': rule_type,
+        'sort': 'created_date|desc',
+        'limit': 1
+    }
+
+    query_result = falcon.query_rule_ids(**query_params)
+
+    handle_return_errors(module, result, query_result)
+
+    rule_ids = query_result.get('body', {}).get('resources', [])
+    if not rule_ids:
+        module.fail_json(msg=f"No rules found for type: {rule_type}")
+
+    return rule_ids[0]
+
+
+def get_rule_details(module, falcon, rule_id, result):
+    """Get details about a specific rule."""
+    query_result = falcon.get_rule_entities(ids=[rule_id])
+
+    handle_return_errors(module, result, query_result)
+
+    rules = query_result.get('body', {}).get('resources', [])
+    if not rules:
+        module.fail_json(msg=f"No rule found with ID: {rule_id}")
+
+    return rules[0]
+
+
+def download_rule_file(module, falcon, rule_id, compression_format):
+    """Download a rule file."""
+    if module.params.get('rule_id'):
+        # Download specific rule file by ID
+        download = falcon.get_rule_file(id=rule_id, format=compression_format)
+    else:
+        # Download latest rule file by type
+        download = falcon.get_latest_rule_file(type=module.params.get('type'), format=compression_format)
+
+    if isinstance(download, dict) and "status_code" in download:
+        # Error occurred
+        module.fail_json(
+            msg=f"Failed to download rule file: {download.get('body', {}).get('errors', [{'message': 'Unknown error'}])[0].get('message')}"
+        )
+
+    return download
+
+
+def handle_existing_file(module, result, path):
+    """Handle the case where the file already exists."""
+    # We can't reliably check the content without downloading again,
+    # so we'll assume it needs to be updated if it exists
+    msg = "File already exists but may have been updated."
+
+    if update_permissions(module, result["changed"], path):
+        msg += " Permissions were updated."
+        result.update(changed=True)
+
+    module.exit_json(
+        msg=msg,
+        path=path,
+        **result,
+    )
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        add_file_common_args=True,
+        supports_check_mode=True,
+        required_one_of=[['type', 'rule_id']],
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+
+    rule_id = module.params.get("rule_id")
+    rule_type = module.params.get("type")
+    compression_format = module.params.get("format")
+    dest = module.params.get("dest")
+    name = module.params.get("name")
+    tmp_dir = False
+
+    if not dest:
+        dest = mkdtemp()
+        os.chmod(dest, 0o755)  # nosec
+        tmp_dir = True
+
+    # Make sure path exists and is a directory
+    check_destination_path(module, dest)
+
+    # Authenticate and initialize
+    falcon = authenticate(module, Intel)
+    result = dict(
+        changed=False,
+    )
+
+    # If rule_id is not provided, get the latest rule ID for the specified type
+    if not rule_id:
+        if not rule_type:
+            module.fail_json(msg="Either rule_id or type must be provided.")
+        rule_id = get_latest_rule_id(module, falcon, rule_type, result)
+
+    # Get rule details to include in the result
+    rule_details = get_rule_details(module, falcon, rule_id, result)
+    result.update(
+        rule_id=rule_id,
+        rule_name=rule_details.get('name'),
+        rule_type=rule_details.get('type')
+    )
+
+    # Set the filename if not provided
+    if not name:
+        rule_type_name = rule_details.get('type', 'rule')
+        name = f"{rule_type_name}-{rule_id}.{compression_format}"
+
+    path = os.path.join(dest, name)
+    lock = None
+
+    try:
+        lock = lock_file(path, timeout=300, retry_interval=5)
+        if not lock:
+            module.fail_json(msg=f"Unable to acquire lock for file: {path} after 5 minutes.", **result)
+
+        # Check if the file already exists
+        if not tmp_dir and os.path.isfile(path):
+            handle_existing_file(module, result, path)
+
+        # If we get here, the file either doesn't exist or has changed
+        result.update(changed=True)
+
+        if module.check_mode:
+            module.exit_json(
+                msg=f"File would have been downloaded: {path}",
+                path=path,
+                **result,
+            )
+
+        # Download the rule file
+        file_content = download_rule_file(module, falcon, rule_id, compression_format)
+
+        # Save the file
+        with open(path, "wb") as save_file:
+            save_file.write(file_content)
+
+        # Set permissions on the file
+        update_permissions(module, result["changed"], path)
+
+        result.update(path=path)
+        module.exit_json(**result)
+    except Exception as e:
+        module.fail_json(msg=f"Error downloading rule file: {str(e)}", **result)
+    finally:
+        if lock:
+            unlock_file(lock)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/intel_rule_download.py
+++ b/plugins/modules/intel_rule_download.py
@@ -77,7 +77,7 @@ requirements:
   - Rules (Falcon Intelligence) [B(READ)] API scope
 
 author:
-  - CrowdStrike (@crowdstrike)
+  - Carlos Matos (@carlosmmatos)
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/intel_rule_info.py
+++ b/plugins/modules/intel_rule_info.py
@@ -47,7 +47,6 @@ options:
   tags:
     description:
       - Search for rule tags.
-      - List of strings.
     type: list
     elements: str
   q:
@@ -68,6 +67,10 @@ options:
 extends_documentation_fragment:
   - crowdstrike.falcon.credentials
   - crowdstrike.falcon.credentials.auth
+
+notes:
+  - For large sets of Rule IDs (if not using limits) there may be a delay in processing as the current
+    API endpoint for retrieving details can only process 10 at a time.
 
 author:
   - Carlos Matos (@carlosmmatos)
@@ -211,7 +214,7 @@ def _get_rule_ids(module, falcon, query_params, result):
         result: Results dict
 
     Returns:
-        The final API response containing all rule IDs
+        A list of Rule IDs
     """
     # Check if limit is specified
     user_limit = module.params.get('limit')

--- a/plugins/modules/intel_rule_info.py
+++ b/plugins/modules/intel_rule_info.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: intel_rule_info
+
+short_description: Get information about CrowdStrike Falcon Intel rules
+
+description:
+  - Search for and retrieve details about Intel rules in the CrowdStrike Falcon platform.
+
+options:
+  type:
+    description:
+      - The rule news report type.
+    type: str
+    required: true
+    choices:
+      - common-event-format
+      - netwitness
+      - snort-suricata-changelog
+      - snort-suricata-master
+      - snort-suricata-update
+      - yara-changelog
+      - yara-master
+      - yara-update
+      - cql-master
+      - cql-changelog
+      - cql-update
+  name:
+    description:
+      - Search by rule title.
+    type: list
+    elements: str
+  description:
+    description:
+      - Substring match on the description field.
+    type: list
+    elements: str
+  tags:
+    description:
+      - Search for rule tags.
+      - List of strings.
+    type: list
+    elements: str
+  q:
+    description:
+      - Perform a generic substring search across all fields.
+    type: str
+  min_created_date:
+    description:
+      - Filter results to those created on or after a certain date.
+    type: str
+  max_created_date:
+    description:
+      - Filter results to those created on or before a certain date.
+    type: str
+  sort:
+    description:
+      - The property to sort by in FQL (Falcon Query Language) syntax (e.g. created_date|asc).
+      - See the L(FalconPy documentation,https://www.falconpy.io/Usage/Falcon-Query-Language.html#using-fql-in-a-sort)
+        for more information about sorting with FQL.
+    type: str
+  limit:
+    description:
+      - The maximum number of rule IDs to return. [integer, 1-5000]
+    type: int
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+author:
+  - Carlos Matos (@carlosmmatos)
+
+"""
+
+EXAMPLES = r"""
+- name: Get details on the latest 50 YARA rules
+  crowdstrike.falcon.intel_rule_info:
+    type: "yara-master"
+    limit: 50
+    sort: "created_date|desc"
+
+- name: Get Snort/Suricata rules with a specific description pattern
+  crowdstrike.falcon.intel_rule_info:
+    type: "snort-suricata-master"
+    description:
+      - "FANCY BEAR"
+
+- name: Search for rules with specific tags
+  crowdstrike.falcon.intel_rule_info:
+    type: "yara-master"
+    tags:
+      - "ransomware"
+      - "malware"
+
+- name: Search rules by creation date range
+  crowdstrike.falcon.intel_rule_info:
+    type: "common-event-format"
+    min_created_date: "2023-01-01T00:00:00Z"
+    max_created_date: "2023-12-31T23:59:59Z"
+"""
+
+RETURN = r"""
+rules:
+  description: List of intel rules and their details
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    id:
+      description: The ID of the rule
+      type: int
+      returned: always
+      sample: 1745571604
+    name:
+      description: The name of the rule
+      type: str
+      returned: always
+      sample: "CrowdStrike Intelligence Feed: YARA Master - 2025/04/25"
+    type:
+      description: Type of rule (yara-master, snort-suricata-master, etc.)
+      type: str
+      returned: always
+      sample: "yara-master"
+    created_date:
+      description: Unix timestamp when the rule was created
+      type: int
+      returned: always
+      sample: 1745576262
+    last_modified_date:
+      description: Unix timestamp when the rule was last modified
+      type: int
+      returned: always
+      sample: 1745576262
+    description:
+      description: Full description of the rule
+      type: str
+      returned: always
+    short_description:
+      description: Abbreviated description of the rule
+      type: str
+      returned: always
+    rich_text_description:
+      description: HTML-formatted description of the rule
+      type: str
+      returned: when available
+    tags:
+      description: List of tags associated with the rule
+      type: list
+      elements: str
+      returned: when available
+      sample: ["intel_feed", "yara"]
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+    get_paginated_results_info,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import Intel
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(
+        type=dict(
+            type='str',
+            required=True,
+            choices=[
+                'common-event-format',
+                'netwitness',
+                'snort-suricata-changelog',
+                'snort-suricata-master',
+                'snort-suricata-update',
+                'yara-changelog',
+                'yara-master',
+                'yara-update',
+                'cql-master',
+                'cql-changelog',
+                'cql-update'
+            ]
+        ),
+        name=dict(type='list', elements='str'),
+        description=dict(type='list', elements='str'),
+        tags=dict(type='list', elements='str'),
+        q=dict(type='str'),
+        min_created_date=dict(type='str'),
+        max_created_date=dict(type='str'),
+        sort=dict(type='str'),
+        limit=dict(type='int'),
+    )
+    return args
+
+
+def _get_rule_ids(module, falcon, query_params, result):
+    """Return Intel rule IDs with pagination handling.
+
+    Args:
+        module: The AnsibleModule instance
+        falcon: The authenticated Intel service instance
+        query_params: Dict of parameters to pass to query_rule_ids
+        result: Results dict
+
+    Returns:
+        The final API response containing all rule IDs
+    """
+    # Check if limit is specified
+    user_limit = module.params.get('limit')
+    rule_ids = []
+
+    # If no limit is specified, we'll paginate to get all results
+    if user_limit is None:
+        max_limit = 5000
+        query_result = get_paginated_results_info(
+            module,
+            query_params,
+            max_limit,
+            falcon.query_rule_ids,
+            list_name="rule_ids"
+        )
+        # Get the ids
+        rule_ids = query_result.get('rule_ids')
+    else:
+        # User specified a limit, use it directly
+        query_params['limit'] = user_limit
+        query_result = falcon.query_rule_ids(**query_params)
+        if query_result["status_code"] != 200:
+            handle_return_errors(module, result, query_result)
+        # Get the ids
+        rule_ids = query_result.get('body', {}).get('resources', [])
+
+    return rule_ids
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+
+    falcon = authenticate(module, Intel)
+
+    result = dict(
+        changed=False,
+        rules=[]
+    )
+
+    # Query rule IDs using the correct parameters
+    query_params = {}
+
+    # Build query parameters from module parameters based on docstring
+    param_mapping = {
+        'type': 'type',
+        'name': 'name',
+        'description': 'description',
+        'tags': 'tags',
+        'q': 'q',
+        'min_created_date': 'min_created_date',
+        'max_created_date': 'max_created_date',
+        'sort': 'sort',
+    }
+
+    for ansible_param, api_param in param_mapping.items():
+        value = module.params.get(ansible_param)
+        if value is not None:
+            query_params[api_param] = value
+
+    # If limit is used, then we need to honor it, otherwise, paginate (if needed)
+    rule_ids = _get_rule_ids(
+        module,
+        falcon,
+        query_params,
+        result
+    )
+
+    if not rule_ids:
+        module.exit_json(**result)
+
+    # Get rule details in batches
+    # Process in batches of 10 (API default limit)
+    for i in range(0, len(rule_ids), 10):
+        batch_ids = rule_ids[i:i + 10]
+        query_result = falcon.get_rule_entities(ids=batch_ids)
+
+        if query_result["status_code"] == 200:
+            result["rules"].extend(query_result["body"]["resources"])
+        else:
+            handle_return_errors(module, result, query_result)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/intel_rule_info.py
+++ b/plugins/modules/intel_rule_info.py
@@ -72,6 +72,9 @@ notes:
   - For large sets of Rule IDs (if not using limits) there may be a delay in processing as the current
     API endpoint for retrieving details can only process 10 at a time.
 
+requirements:
+  - Rules (Falcon Intelligence) [B(READ)] API scope
+
 author:
   - Carlos Matos (@carlosmmatos)
 

--- a/plugins/modules/intel_rule_info.py
+++ b/plugins/modules/intel_rule_info.py
@@ -54,14 +54,6 @@ options:
     description:
       - Perform a generic substring search across all fields.
     type: str
-  min_created_date:
-    description:
-      - Filter results to those created on or after a certain date.
-    type: str
-  max_created_date:
-    description:
-      - Filter results to those created on or before a certain date.
-    type: str
   sort:
     description:
       - The property to sort by in FQL (Falcon Query Language) syntax (e.g. created_date|asc).
@@ -99,14 +91,8 @@ EXAMPLES = r"""
   crowdstrike.falcon.intel_rule_info:
     type: "yara-master"
     tags:
-      - "ransomware"
-      - "malware"
-
-- name: Search rules by creation date range
-  crowdstrike.falcon.intel_rule_info:
-    type: "common-event-format"
-    min_created_date: "2023-01-01T00:00:00Z"
-    max_created_date: "2023-12-31T23:59:59Z"
+      - "intel_feed"
+      - "yara"
 """
 
 RETURN = r"""
@@ -209,8 +195,6 @@ def argspec():
         description=dict(type='list', elements='str'),
         tags=dict(type='list', elements='str'),
         q=dict(type='str'),
-        min_created_date=dict(type='str'),
-        max_created_date=dict(type='str'),
         sort=dict(type='str'),
         limit=dict(type='int'),
     )
@@ -288,8 +272,6 @@ def main():
         'description': 'description',
         'tags': 'tags',
         'q': 'q',
-        'min_created_date': 'min_created_date',
-        'max_created_date': 'max_created_date',
         'sort': 'sort',
     }
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ commands =
 [testenv:pylint]
 deps = pylint
 commands =
-    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913,R0902,R0903'
+    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913,R0902,R0903,R0917'


### PR DESCRIPTION
Closes #587 

This PR introduces two new modules surrounding our Intel Rules:
1. `intel_rule_info` - Get information on Intel rule files based on search criteria
2. `intel_rule_download` - Download an Intel rule file