### PR TITLE
ci: invalidate pycache and use requirements.txt for devcontainer

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -6,7 +6,7 @@ pylint
 pre-commit
 autopep8
 ansible
-ansible-core
+ansible-core==2.16.7
 ansible-lint
 boto3
 botocore

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Perform sanity testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          ansible-core-version: stable-2.15
+          ansible-core-version: stable-2.18
           testing-type: sanity
           pre-test-cmd: 'rm -rf .devcontainer/ .git* .pre-commit-config.yaml'

--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/falcon_configure.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/falcon_configure_remove_aid.yml
+++ b/.github/workflows/falcon_configure_remove_aid.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/falcon_configure_remove_aid.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/falcon_install.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/falcon_uninstall.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/win_falcon_configure.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/win_falcon_install.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/win_falcon_uninstall.yml'
+          cache-dependency-path: '.devcontainer/requirements.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
reverting back #604 since we still need to support legacy OS' that we support.. will need to figure out a better way forward to test this matrix version compat for ansible-core support