### PR TITLE
ci: remove debian-11 from test matrix

### DIFF
--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -77,11 +77,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - falcon_configure
     steps:

--- a/.github/workflows/falcon_configure_remove_aid.yml
+++ b/.github/workflows/falcon_configure_remove_aid.yml
@@ -78,11 +78,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - falcon_configure_remove_aid
     steps:

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -77,11 +77,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - falcon_install
           - falcon_install_policy

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -77,11 +77,6 @@ jobs:
             image_arch: arm64
             image_name: RHEL-9.?.?_HVM-*
             instance_type: t4g.micro
-          - distro: debian-11
-            image_owner: '136693071363'
-            image_arch: x86_64
-            image_name: debian-11-amd64-*
-            instance_type: t2.micro
         collection_role:
           - falcon_uninstall
     steps:


### PR DESCRIPTION
Debian 11 is now in LTS mode with limited support and the backports are decommissioned