### PR TITLE
Check response code

### DIFF
--- a/changelogs/fragments/host-hide-handle-403.yml
+++ b/changelogs/fragments/host-hide-handle-403.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "host_hide module - Raise errors back to Ansible when the status code returned from the API is a 403"

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.errors import AnsibleError
 
 __metaclass__ = type
 
@@ -189,6 +190,11 @@ def handle_bad_hosts(bad, host_mapping, result):
 def process_hosts(module, falcon, action_name, hosts, result):
     """Process the hosts to hide or unhide."""
     query_result = falcon.perform_action(action_name=action_name, ids=hosts)
+
+    if query_result["status_code"] != 200:
+        raise AnsibleError(
+            f"Unable to hide/unhide hosts: {query_result['body']['errors']}"
+        )
 
     # The API returns both successful and failed hosts in the same response. This
     # means we need to handle errors differently than we normally would.

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -191,7 +191,7 @@ def process_hosts(module, falcon, action_name, hosts, result):
     """Process the hosts to hide or unhide."""
     query_result = falcon.perform_action(action_name=action_name, ids=hosts)
 
-    if query_result["status_code"] != 200:
+    if query_result["status_code"] == 403:
         raise AnsibleError(
             f"Unable to hide/unhide hosts: {query_result['body']['errors']}"
         )

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -5,7 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.errors import AnsibleError
 
 __metaclass__ = type
 
@@ -192,8 +191,8 @@ def process_hosts(module, falcon, action_name, hosts, result):
     query_result = falcon.perform_action(action_name=action_name, ids=hosts)
 
     if query_result["status_code"] == 403:
-        raise AnsibleError(
-            f"Unable to hide/unhide hosts: {query_result['body']['errors']}"
+        module.fail_json(
+            msg=f"Unable to hide/unhide hosts: {query_result['body']['errors']}"
         )
 
     # The API returns both successful and failed hosts in the same response. This


### PR DESCRIPTION
My service account currently returns a 403 on this API due to lack of permissions, but this module is lacking error handling on the status code so boils up as `KeyError: 'resources'`

Given that we process hosts in batches of 100 and we add good/bad to an array, I think we should check for an explicit 403 rather than a non-200 code (as I assume the API can return other 400 status codes) - but should never return a 403 unless we don't have permissions.