### PR TITLE
feat: add host group management modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Name | Description
 [crowdstrike.falcon.host_contain](https://crowdstrike.github.io/ansible_collection_falcon/host_contain_module.html)|Network contain hosts in Falcon
 [crowdstrike.falcon.host_hide](https://crowdstrike.github.io/ansible_collection_falcon/host_hide_module.html)|Hide/Unhide hosts from the Falcon console. Preference should be given to using `Host Retention Policies` under `Host Management` in the Falcon console which provides more flexibility and customization for automatically hiding and deleting hosts instead.
 [crowdstrike.falcon.host_info](https://crowdstrike.github.io/ansible_collection_falcon/host_info_module.html)|Get information about Falcon hosts
+[crowdstrike.falcon.host_group](https://crowdstrike.github.io/ansible_collection_falcon/host_group_module.html)|Manage Falcon host groups
+[crowdstrike.falcon.host_group_info](https://crowdstrike.github.io/ansible_collection_falcon/host_group_info_module.html)|Get information about Falcon host groups
 [crowdstrike.falcon.hunting_rule_download](https://crowdstrike.github.io/ansible_collection_falcon/hunting_rule_download_module.html)|Download CrowdStrike Falcon Hunting rule archives
 [crowdstrike.falcon.intel_rule_download](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_download_module.html)|Download CrowdStrike Falcon Intel rule files
 [crowdstrike.falcon.intel_rule_info](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_info_module.html)|Get information about CrowdStrike Falcon Intel rules

--- a/changelogs/fragments/494-add-host-group-modules.yml
+++ b/changelogs/fragments/494-add-host-group-modules.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - host_group module - Add new module to manage CRUD operations for Falcon host groups including
+    create, update, delete, and host membership management (addresses # 494)
+  - host_group_info module - Add new module to retrieve information about Falcon host groups with
+    filtering, pagination, and optional member details (addresses # 494)

--- a/plugins/modules/host_group.py
+++ b/plugins/modules/host_group.py
@@ -1,0 +1,576 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: host_group
+
+short_description: Manage Falcon host groups
+
+version_added: "4.10.0"
+
+description:
+  - Create, update, delete, and manage Falcon host groups.
+  - Supports static, dynamic, and staticByID group types.
+  - Can manage host group membership by adding or removing hosts.
+  - Provides idempotent operations that only make changes when necessary.
+
+options:
+  state:
+    description:
+      - The desired state of the host group.
+      - C(present) ensures the host group exists with the specified configuration.
+      - C(absent) ensures the host group does not exist.
+    type: str
+    choices: ["present", "absent"]
+    default: present
+  name:
+    description:
+      - The name of the host group.
+      - Required when I(state=present) and creating a new group.
+      - Cannot be used to rename existing groups (use I(host_group) to identify the group).
+    type: str
+    required: false
+  host_group:
+    description:
+      - The ID of an existing host group.
+      - Required when I(state=absent) or when updating an existing group.
+      - If provided with I(state=present), the module will update the existing group.
+    type: str
+    required: false
+  description:
+    description:
+      - A description for the host group.
+      - Only used when I(state=present).
+    type: str
+    required: false
+  group_type:
+    description:
+      - The type of host group to create or validate.
+      - C(static) groups contain manually assigned hosts.
+      - C(dynamic) groups automatically include hosts based on assignment rules.
+      - C(staticByID) groups contain hosts assigned by their device IDs.
+      - Cannot be changed after group creation.
+    type: str
+    choices: ["static", "dynamic", "staticByID"]
+    default: static
+  assignment_rule:
+    description:
+      - FQL (Falcon Query Language) filter for dynamic group membership.
+      - Required when I(group_type=dynamic).
+      - Ignored for static and staticByID groups.
+      - "Examples: C(platform_name:'Linux'), C(tags:'production'+os_version:'*Server*')."
+    type: str
+    required: false
+  hosts:
+    description:
+      - List of host IDs (AIDs) to add to or remove from the host group.
+      - Use with I(host_action) to specify the operation.
+      - Only applicable for existing groups and when I(state=present).
+    type: list
+    elements: str
+    required: false
+  host_action:
+    description:
+      - The action to perform with the hosts specified in I(hosts).
+      - C(add) adds hosts to the group.
+      - C(remove) removes hosts from the group.
+      - Requires I(hosts) to be specified.
+    type: str
+    choices: ["add", "remove"]
+    required: false
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+notes:
+  - B(Idempotency:) This module is idempotent and will only make changes when the
+    current state differs from the desired state.
+  - B(Group Types:) The group type cannot be changed after creation. To change
+    a group's type, delete the existing group and create a new one.
+  - B(Dynamic Groups:) Assignment rules for dynamic groups are evaluated by
+    CrowdStrike's backend and may take some time to reflect membership changes.
+  - B(Host Management:) Adding or removing hosts only works with existing groups.
+    Host operations are performed after group creation/update operations.
+
+requirements:
+  - Host Groups [B(READ), B(WRITE)] API scope
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Create a static host group
+  crowdstrike.falcon.host_group:
+    name: "Web Servers"
+    description: "All web server hosts"
+    group_type: static
+
+- name: Create a dynamic host group
+  crowdstrike.falcon.host_group:
+    name: "Linux Production"
+    description: "All Linux hosts in production"
+    group_type: dynamic
+    assignment_rule: "platform_name:'Linux'+tags:'production'"
+
+- name: Update an existing host group description
+  crowdstrike.falcon.host_group:
+    host_group: "12345678901234567890abcdef123456"
+    description: "Updated description for web servers"
+
+- name: Add hosts to an existing group
+  crowdstrike.falcon.host_group:
+    host_group: "12345678901234567890abcdef123456"
+    hosts:
+      - "d78cd791785442a98ec75249d8c385dd"
+      - "a1b2c3d4e5f6789012345678901234ab"
+    host_action: add
+
+- name: Remove hosts from a group
+  crowdstrike.falcon.host_group:
+    host_group: "12345678901234567890abcdef123456"
+    hosts:
+      - "d78cd791785442a98ec75249d8c385dd"
+    host_action: remove
+
+- name: Delete a host group
+  crowdstrike.falcon.host_group:
+    host_group: "12345678901234567890abcdef123456"
+    state: absent
+
+- name: Create or update a group (idempotent)
+  crowdstrike.falcon.host_group:
+    name: "Database Servers"
+    description: "All database server hosts"
+    group_type: static
+  register: db_group
+
+- name: Add hosts to the group created above
+  crowdstrike.falcon.host_group:
+    host_group: "{{ db_group.host_group.id }}"
+    hosts: "{{ database_host_ids }}"
+    host_action: add
+"""
+
+RETURN = r"""
+host_group:
+  description:
+    - Information about the host group that was created, updated, or managed.
+  type: dict
+  returned: when state=present
+  contains:
+    id:
+      description: The unique identifier of the host group.
+      type: str
+      returned: success
+      sample: "12345678901234567890abcdef123456"
+    name:
+      description: The name of the host group.
+      type: str
+      returned: success
+      sample: "Web Servers"
+    description:
+      description: The description of the host group.
+      type: str
+      returned: success
+      sample: "All web server hosts"
+    group_type:
+      description: The type of host group (static, dynamic, or staticByID).
+      type: str
+      returned: success
+      sample: "static"
+    assignment_rule:
+      description: The assignment rule for dynamic groups.
+      type: str
+      returned: when group_type=dynamic
+      sample: "platform_name:'Linux'+tags:'production'"
+    created_by:
+      description: The user who created the host group.
+      type: str
+      returned: success
+      sample: "user@example.com"
+    created_timestamp:
+      description: The timestamp when the host group was created.
+      type: str
+      returned: success
+      sample: "2024-01-15T10:30:00.000000Z"
+    modified_by:
+      description: The user who last modified the host group.
+      type: str
+      returned: success
+      sample: "admin@example.com"
+    modified_timestamp:
+      description: The timestamp when the host group was last modified.
+      type: str
+      returned: success
+      sample: "2024-02-01T14:22:30.000000Z"
+action_results:
+  description:
+    - Results of host management actions (add/remove hosts).
+  type: dict
+  returned: when host_action is performed
+  contains:
+    successful_hosts:
+      description: List of host IDs that were successfully added or removed.
+      type: list
+      returned: success
+      elements: str
+      sample: ["d78cd791785442a98ec75249d8c385dd"]
+    failed_hosts:
+      description: List of host IDs that failed to be added or removed.
+      type: list
+      returned: when some hosts fail
+      elements: dict
+      contains:
+        id:
+          description: The host ID that failed.
+          type: str
+          returned: success
+          sample: "a1b2c3d4e5f6789012345678901234ab"
+        code:
+          description: The error code returned by the API.
+          type: int
+          returned: success
+          sample: 404
+        message:
+          description: The error message returned by the API.
+          type: str
+          returned: success
+          sample: "Host not found"
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import HostGroup
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+HOST_GROUP_ARGS = {
+    "state": {"type": "str", "choices": ["present", "absent"], "default": "present"},
+    "name": {"type": "str", "required": False},
+    "host_group": {"type": "str", "required": False},
+    "description": {"type": "str", "required": False},
+    "group_type": {
+        "type": "str",
+        "choices": ["static", "dynamic", "staticByID"],
+        "default": "static",
+    },
+    "assignment_rule": {"type": "str", "required": False},
+    "hosts": {"type": "list", "elements": "str", "required": False},
+    "host_action": {"type": "str", "choices": ["add", "remove"], "required": False},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(HOST_GROUP_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    state = module.params["state"]
+    name = module.params.get("name")
+    host_group = module.params.get("host_group")
+    group_type = module.params["group_type"]
+    assignment_rule = module.params.get("assignment_rule")
+    hosts = module.params.get("hosts")
+    host_action = module.params.get("host_action")
+
+    # Validate required parameters for different states
+    if state == "present":
+        if not host_group and not name:
+            module.fail_json(
+                msg="Either 'name' (for new groups) or 'host_group' (for existing groups) is required when state=present"
+            )
+    elif state == "absent":
+        if not host_group:
+            module.fail_json(
+                msg="Parameter 'host_group' is required when state=absent"
+            )
+
+    # Validate dynamic group requirements
+    if group_type == "dynamic" and state == "present" and not assignment_rule:
+        module.fail_json(
+            msg="Parameter 'assignment_rule' is required when group_type=dynamic"
+        )
+
+    # Validate host action parameters
+    if host_action and not hosts:
+        module.fail_json(
+            msg="Parameter 'hosts' is required when 'host_action' is specified"
+        )
+
+    if hosts and not host_action:
+        module.fail_json(
+            msg="Parameter 'host_action' is required when 'hosts' is specified"
+        )
+
+
+def get_existing_group(falcon, host_group_id):
+    """Get an existing host group by ID."""
+    result = falcon.get_host_groups(ids=[host_group_id])
+    if result["status_code"] == 200 and result["body"]["resources"]:
+        return result["body"]["resources"][0]
+    return None
+
+
+def find_group_by_name(falcon, name):
+    """Find a host group by name using search."""
+    result = falcon.query_combined_host_groups(filter=f"name:'{name}'", limit=1)
+    if result["status_code"] == 200 and result["body"]["resources"]:
+        return result["body"]["resources"][0]
+    return None
+
+
+def create_host_group(falcon, module):
+    """Create a new host group."""
+    params = {
+        "name": module.params["name"],
+        "group_type": module.params["group_type"],
+    }
+
+    if module.params.get("description"):
+        params["description"] = module.params["description"]
+
+    if module.params.get("assignment_rule"):
+        params["assignment_rule"] = module.params["assignment_rule"]
+
+    return falcon.create_host_groups(**params)
+
+
+def update_host_group(falcon, module, group_id):
+    """Update an existing host group."""
+    params = {
+        "id": group_id,
+    }
+
+    # Only include parameters that should be updated
+    if module.params.get("name"):
+        params["name"] = module.params["name"]
+
+    if module.params.get("description") is not None:
+        params["description"] = module.params["description"]
+
+    if module.params.get("assignment_rule") is not None:
+        params["assignment_rule"] = module.params["assignment_rule"]
+
+    return falcon.update_host_groups(**params)
+
+
+def delete_host_group(falcon, host_group_id):
+    """Delete a host group."""
+    return falcon.delete_host_groups(ids=[host_group_id])
+
+
+def perform_host_action(falcon, module, group_id):
+    """Add or remove hosts from a group."""
+    action_name = (
+        "add-hosts" if module.params["host_action"] == "add" else "remove-hosts"
+    )
+
+    # Create filter for the hosts
+    host_ids = module.params["hosts"]
+    quoted_ids = '","'.join(host_ids)
+    device_filter = f'device_id:["{quoted_ids}"]'
+
+    return falcon.perform_group_action(
+        action_name=action_name, ids=[group_id], filter=device_filter
+    )
+
+
+def process_host_action_results(result):
+    """Process the results of a host action to separate successful and failed hosts."""
+    successful_hosts = []
+    failed_hosts = []
+
+    # Extract successful operations
+    if "resources" in result["body"] and result["body"]["resources"]:
+        for resource in result["body"]["resources"]:
+            if "id" in resource:
+                successful_hosts.append(resource["id"])
+
+    # Extract failed operations
+    if "errors" in result["body"] and result["body"]["errors"]:
+        for error in result["body"]["errors"]:
+            failed_hosts.append(
+                {
+                    "code": error.get("code", 0),
+                    "message": error.get("message", "Unknown error"),
+                }
+            )
+
+    return {"successful_hosts": successful_hosts, "failed_hosts": failed_hosts}
+
+
+def group_needs_update(current_group, module):
+    """Check if the current group needs to be updated based on module parameters."""
+    needs_update = False
+
+    # Check name (only if provided and different)
+    if module.params.get("name") and current_group.get("name") != module.params["name"]:
+        needs_update = True
+
+    # Check description (only if provided and different)
+    if (
+        module.params.get("description") is not None
+        and current_group.get("description") != module.params["description"]
+    ):
+        needs_update = True
+
+    # Check assignment_rule for dynamic groups (only if provided and different)
+    if (
+        module.params.get("assignment_rule") is not None
+        and current_group.get("assignment_rule") != module.params["assignment_rule"]
+    ):
+        needs_update = True
+
+    return needs_update
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+    validate_params(module)
+
+    state = module.params["state"]
+    host_group = module.params.get("host_group")
+    name = module.params.get("name")
+
+    result = dict(
+        changed=False,
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    falcon = authenticate(module, HostGroup)
+
+    try:
+        if state == "present":
+            current_group = None
+
+            # Find existing group
+            if host_group:
+                current_group = get_existing_group(falcon, host_group)
+                if not current_group:
+                    module.fail_json(
+                        msg=f"Host group with ID '{host_group}' not found"
+                    )
+            elif name:
+                current_group = find_group_by_name(falcon, name)
+
+            if current_group:
+                # Update existing group if needed
+                if group_needs_update(current_group, module):
+                    update_result = update_host_group(
+                        falcon, module, current_group["id"]
+                    )
+                    if update_result["status_code"] != 200:
+                        handle_return_errors(module, result, update_result)
+                    result["changed"] = True
+
+                    # Get updated group info
+                    updated_group = get_existing_group(falcon, current_group["id"])
+                    result["host_group"] = (
+                        updated_group if updated_group else current_group
+                    )
+                else:
+                    result["host_group"] = current_group
+
+                # Perform host actions if specified
+                if module.params.get("hosts") and module.params.get("host_action"):
+                    action_result = perform_host_action(
+                        falcon, module, current_group["id"]
+                    )
+                    if action_result["status_code"] != 200:
+                        # For host actions, we may have partial success, so process the results
+                        result["action_results"] = process_host_action_results(
+                            action_result
+                        )
+                        if result["action_results"]["successful_hosts"]:
+                            result["changed"] = True
+                    else:
+                        result["action_results"] = process_host_action_results(
+                            action_result
+                        )
+                        result["changed"] = True
+
+            else:
+                # Create new group
+                create_result = create_host_group(falcon, module)
+                if create_result["status_code"] != 201:
+                    handle_return_errors(module, result, create_result)
+
+                if create_result["body"]["resources"]:
+                    new_group_id = create_result["body"]["resources"][0]["id"]
+                    result["host_group"] = create_result["body"]["resources"][0]
+                    result["changed"] = True
+
+                    # Perform host actions if specified for new group
+                    if module.params.get("hosts") and module.params.get("host_action"):
+                        action_result = perform_host_action(
+                            falcon, module, new_group_id
+                        )
+                        result["action_results"] = process_host_action_results(
+                            action_result
+                        )
+                        if result["action_results"]["successful_hosts"]:
+                            result["changed"] = True
+
+        elif state == "absent":
+            # Check if group exists
+            current_group = get_existing_group(falcon, host_group)
+            if current_group:
+                # Delete the group
+                delete_result = delete_host_group(falcon, host_group)
+                if delete_result["status_code"] != 200:
+                    handle_return_errors(module, result, delete_result)
+                result["changed"] = True
+
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while managing the host group: {str(e)}", **result
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/host_group_info.py
+++ b/plugins/modules/host_group_info.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: host_group_info
+
+short_description: Get information about Falcon host groups
+
+version_added: "4.10.0"
+
+description:
+  - Returns detailed information for one or more host groups.
+  - Some of the details returned include group name, description, group type,
+    assignment rules, creation and modification timestamps, and member counts.
+  - Can retrieve specific host groups by ID or search for groups using FQL filters.
+  - Optionally includes detailed member information for each group.
+
+options:
+  host_groups:
+    description:
+      - A list of host group IDs to get information about.
+      - If not provided, all accessible host groups will be returned (subject to filter and pagination).
+    type: list
+    elements: str
+    required: false
+  filter:
+    description:
+      - FQL (Falcon Query Language) filter expression to limit results.
+      - "Examples: C(name:'Production*'), C(group_type:'dynamic'), C(created_timestamp:>'2024-01-01T00:00:00Z')."
+      - Cannot be used together with I(host_groups).
+    type: str
+    required: false
+  limit:
+    description:
+      - Maximum number of host groups to return.
+      - Must be between 1 and 5000.
+    type: int
+    default: 100
+  offset:
+    description:
+      - Starting index for pagination.
+      - Use with I(limit) to paginate through large result sets.
+    type: int
+    default: 0
+  sort:
+    description:
+      - Property to sort results by.
+      - Prefix with C(-) for descending order.
+      - "Examples: C(name), C(-created_timestamp), C(group_type)."
+    type: str
+    required: false
+  include_members:
+    description:
+      - Whether to include detailed member information for each host group.
+      - When enabled, adds a C(members) list to each group with host details.
+      - This may significantly increase response time and size for groups with many members.
+    type: bool
+    default: false
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+requirements:
+  - Host Groups [B(READ)] API scope
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Get information about all host groups
+  crowdstrike.falcon.host_group_info:
+
+- name: Get information about specific host groups
+  crowdstrike.falcon.host_group_info:
+    host_groups:
+      - "12345678901234567890abcdef123456"
+      - "abcdef123456789012345678901234"
+
+- name: Search for host groups by name pattern
+  crowdstrike.falcon.host_group_info:
+    filter: "name:'Production*'"
+    limit: 50
+
+- name: Get dynamic host groups created in the last 7 days
+  crowdstrike.falcon.host_group_info:
+    filter: "group_type:'dynamic'+created_timestamp:>'{{ (ansible_date_time.epoch | int - 604800) }}'"
+    sort: "-created_timestamp"
+
+- name: Get host group information including member details
+  crowdstrike.falcon.host_group_info:
+    host_groups: ["12345678901234567890abcdef123456"]
+    include_members: true
+
+- name: Paginate through all host groups
+  crowdstrike.falcon.host_group_info:
+    limit: 100
+    offset: "{{ page * 100 }}"
+  loop: "{{ range(0, total_groups // 100 + 1) | list }}"
+  loop_control:
+    loop_var: page
+"""
+
+RETURN = r"""
+host_groups:
+  description:
+    - A list of host groups that match the search criteria.
+  type: list
+  returned: success
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the host group.
+      type: str
+      returned: success
+      sample: "12345678901234567890abcdef123456"
+    name:
+      description: The name of the host group.
+      type: str
+      returned: success
+      sample: "Production Servers"
+    description:
+      description: The description of the host group.
+      type: str
+      returned: success
+      sample: "All production server hosts"
+    group_type:
+      description: The type of host group (static, dynamic, or staticByID).
+      type: str
+      returned: success
+      sample: "dynamic"
+    assignment_rule:
+      description: The assignment rule for dynamic groups (FQL filter).
+      type: str
+      returned: success
+      sample: "platform_name:'Linux'+tags:'production'"
+    created_by:
+      description: The user who created the host group.
+      type: str
+      returned: success
+      sample: "user@example.com"
+    created_timestamp:
+      description: The timestamp when the host group was created.
+      type: str
+      returned: success
+      sample: "2024-01-15T10:30:00.000000Z"
+    modified_by:
+      description: The user who last modified the host group.
+      type: str
+      returned: success
+      sample: "admin@example.com"
+    modified_timestamp:
+      description: The timestamp when the host group was last modified.
+      type: str
+      returned: success
+      sample: "2024-02-01T14:22:30.000000Z"
+    group_hash:
+      description: A hash representing the current state of the group.
+      type: str
+      returned: success
+      sample: "abc123def456789"
+    members:
+      description: List of host group members (only when include_members=true).
+      type: list
+      returned: when include_members=true
+      elements: dict
+      contains:
+        device_id:
+          description: The host ID (AID) of the member.
+          type: str
+          returned: success
+          sample: "d78cd791785442a98ec75249d8c385dd"
+        hostname:
+          description: The hostname of the member host.
+          type: str
+          returned: success
+          sample: "web-server-01"
+        platform_name:
+          description: The platform of the member host.
+          type: str
+          returned: success
+          sample: "Linux"
+        last_seen:
+          description: When the member host was last seen.
+          type: str
+          returned: success
+          sample: "2024-02-01T15:45:00Z"
+meta:
+  description: Metadata about the query results.
+  type: dict
+  returned: success
+  contains:
+    query_time:
+      description: Time taken to execute the query in seconds.
+      type: float
+      returned: success
+      sample: 0.123
+    pagination:
+      description: Pagination information.
+      type: dict
+      returned: success
+      contains:
+        offset:
+          description: The starting index used for this query.
+          type: int
+          returned: success
+          sample: 0
+        limit:
+          description: The limit used for this query.
+          type: int
+          returned: success
+          sample: 100
+        total:
+          description: Total number of host groups matching the query.
+          type: int
+          returned: success
+          sample: 1247
+"""
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import HostGroup
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+HOST_GROUP_INFO_ARGS = {
+    "host_groups": {"type": "list", "elements": "str", "required": False},
+    "filter": {"type": "str", "required": False},
+    "limit": {"type": "int", "default": 100},
+    "offset": {"type": "int", "default": 0},
+    "sort": {"type": "str", "required": False},
+    "include_members": {"type": "bool", "default": False},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(HOST_GROUP_INFO_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    # Check mutually exclusive parameters
+    if module.params.get("host_groups") and module.params.get("filter"):
+        module.fail_json(
+            msg="Parameters 'host_groups' and 'filter' are mutually exclusive"
+        )
+
+    # Validate limit range
+    limit = module.params["limit"]
+    if limit < 1 or limit > 5000:
+        module.fail_json(msg="Parameter 'limit' must be between 1 and 5000")
+
+    # Validate offset
+    offset = module.params["offset"]
+    if offset < 0:
+        module.fail_json(msg="Parameter 'offset' must be 0 or greater")
+
+
+def get_host_groups_by_ids(falcon, host_group_ids):
+    """Retrieve host groups by their IDs."""
+    return falcon.get_host_groups(ids=host_group_ids)
+
+
+def search_host_groups(falcon, module):
+    """Search for host groups using filters and pagination."""
+    params = {
+        "limit": module.params["limit"],
+        "offset": module.params["offset"],
+    }
+
+    if module.params.get("filter"):
+        params["filter"] = module.params["filter"]
+
+    if module.params.get("sort"):
+        params["sort"] = module.params["sort"]
+
+    return falcon.query_combined_host_groups(**params)
+
+
+def get_group_members(falcon, group_id):
+    """Get detailed member information for a host group."""
+    return falcon.query_combined_group_members(id=group_id, limit=5000)
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+    validate_params(module)
+
+    start_time = time.time()
+    host_groups = []
+    falcon = authenticate(module, HostGroup)
+
+    result = dict(
+        changed=False,
+        host_groups=[],
+        meta={},
+    )
+
+    try:
+        # Determine which API method to use
+        if module.params.get("host_groups"):
+            # Get specific host groups by ID
+            query_result = get_host_groups_by_ids(
+                falcon, module.params["host_groups"]
+            )
+
+            if query_result["status_code"] == 200:
+                host_groups = query_result["body"]["resources"]
+
+                # Set pagination info for ID-based queries
+                result["meta"] = {
+                    "query_time": time.time() - start_time,
+                    "pagination": {
+                        "offset": 0,
+                        "limit": len(host_groups),
+                        "total": len(host_groups),
+                    },
+                }
+        else:
+            # Search for host groups using filters
+            query_result = search_host_groups(falcon, module)
+
+            if query_result["status_code"] == 200:
+                host_groups = query_result["body"]["resources"]
+
+                # Extract pagination metadata
+                meta = query_result["body"].get("meta", {})
+                result["meta"] = {
+                    "query_time": time.time() - start_time,
+                    "pagination": {
+                        "offset": module.params["offset"],
+                        "limit": module.params["limit"],
+                        "total": meta.get("pagination", {}).get(
+                            "total", len(host_groups)
+                        ),
+                    },
+                }
+
+        # Add member information if requested
+        if module.params["include_members"] and host_groups:
+            for group in host_groups:
+                members_result = get_group_members(falcon, group["id"])
+                if members_result["status_code"] == 200:
+                    group["members"] = members_result["body"]["resources"]
+                else:
+                    # If we can't get members, add empty list and continue
+                    group["members"] = []
+
+        result["host_groups"] = host_groups
+
+        # Handle API errors
+        handle_return_errors(module, result, query_result)
+
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while retrieving host group information: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds host_group and host_group_info modules for managing CrowdStrike Falcon host groups.

## Changes
- Add host_group module for CRUD operations (create, update, delete, host management)
- Add host_group_info module for retrieving host group information with filtering
- Support for static, dynamic, and staticByID group types
- Fix test playbooks parameter mismatches
- Add modules to README.md

## Testing
- All ansible-test sanity tests pass (34/34)
- Tox linting passes
- Ansible-lint passes
- Functional API tests included

Fixes #494