### PR TITLE
fix(falcon_install): resolve type error with falcon_sensor_version_decrement

### DIFF
--- a/changelogs/fragments/655-fix-sensor-version-decrement-type-error.yml
+++ b/changelogs/fragments/655-fix-sensor-version-decrement-type-error.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    falcon_install role - Fix type comparison error when falcon_sensor_version_decrement
+    is passed as a string (https://github.com/CrowdStrike/ansible_collection_falcon/issues/655)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -69,13 +69,13 @@
 - name: CrowdStrike Falcon | Validate available sensor count > decrement (if applicable)
   ansible.builtin.assert:
     that:
-      - falcon_api_installer_list.installers | length > falcon_sensor_version_decrement
+      - falcon_api_installer_list.installers | length > falcon_sensor_version_decrement | int
     fail_msg: >-
       Not enough sensor versions available for the specified decrement value: N-{{ falcon_sensor_version_decrement }}.
       This may occur if your OS distribution/version is newly supported and fewer historical sensor versions exist.
   when:
     - falcon_sensor_version_decrement is defined
-    - falcon_sensor_version_decrement > 0
+    - falcon_sensor_version_decrement | int > 0
 
 - name: CrowdStrike Falcon | Ensure download path exists (local)
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
Fixes type comparison error when `falcon_sensor_version_decrement` is passed as a string from CI/CD environments like GitHub Actions or Packer.

## Changes
- Add `| int` filter to comparisons in `roles/falcon_install/tasks/api.yml`

## Root Cause
Variables passed through external sources (GitHub Actions, Packer) are often strings. The comparisons at lines 72 and 78 didn't use the `| int` filter, causing:
```
'>' not supported between instances of '_AnsibleTaggedStr' and 'int'
```

## Test Plan
- [x] tox (Python linting)
- [x] ansible-test sanity
- [x] ansible-lint

## TODO
- [x] run the falcon_install molecule test

Fixes #655