### PR TITLE
Authentication Error handling - maintenance_token

### DIFF
--- a/plugins/lookup/maintenance_token.py
+++ b/plugins/lookup/maintenance_token.py
@@ -124,7 +124,7 @@ class LookupModule(LookupBase):
         creds = self._credential_setup()
 
         falcon = SensorUpdatePolicy(**creds)
-        if falcon.auth_object._token._status != 200:
+        if falcon.auth_object._token._status != 201:
             raise AnsibleError(
                 f"Unable to obtain OAUTH token: {falcon.auth_object._token._fail_reason}"
             )


### PR DESCRIPTION
When a playbook or user provides one of the following invalid/incorrect information:
- API Client ID
- API Client Secret
- CS (MSSP Member) CID
- CS Cloud tenant

The error from the OAUTH token endpoint is not reported immediately and a blank token is passed into the reveal_uninstall_token endpoint. This leads to confusion that perhaps an improper AID, API Scope, or bulk flag was set when an inevitable HTTP 401 or 403 is returned.

This change will check the returned SensorUpdatePolicy object to make sure OAUTH tokens were properly obtained and immediately error on OAUTH issues (any status other than HTTP 201) rather than wait until the attempt to retrieve an uninstall token. It will display why it was unable to obtain an OAUTH token.