### PR TITLE
feat(lookup): add early auth validation and shared utilities

### DIFF
--- a/changelogs/fragments/664-lookup-plugin-auth-validation.yml
+++ b/changelogs/fragments/664-lookup-plugin-auth-validation.yml
@@ -1,0 +1,12 @@
+---
+bugfixes:
+  - >-
+    lookup plugins - Add early authentication validation to provide clear error messages
+    when OAuth credentials are invalid, instead of failing on subsequent API calls
+    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/664)
+minor_changes:
+  - >-
+    lookup plugins - Refactor shared authentication logic into plugin_utils/falconpy_utils.py
+    for DRY compliance across host_ids, maintenance_token, and fctl_child_cids plugins
+  - >-
+    lookup plugins - Add us-gov-2 to valid cloud regions

--- a/plugins/lookup/host_ids.py
+++ b/plugins/lookup/host_ids.py
@@ -70,21 +70,24 @@ _raw:
   elements: str
 """
 
-import os
 import traceback
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
+from ansible_collections.crowdstrike.falcon.plugins.plugin_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy,
+)
 
 
 FALCONPY_IMPORT_ERROR = None
 try:
     from falconpy import Hosts
-    from falconpy._version import _VERSION
 
     HAS_FALCONPY = True
 except ImportError:
     HAS_FALCONPY = False
+    Hosts = None
     FALCONPY_IMPORT_ERROR = traceback.format_exc()
 
 display = Display()
@@ -93,46 +96,9 @@ display = Display()
 class LookupModule(LookupBase):
     """Lookup plugin for fetching host IDs based on filter expressions."""
 
-    def _credential_setup(self):
-        """Setup credentials for FalconPy."""
-        cred_mapping = {
-            "client_id": "FALCON_CLIENT_ID",
-            "client_secret": "FALCON_CLIENT_SECRET",
-            "member_cid": "FALCON_MEMBER_CID",
-            "cloud": "FALCON_CLOUD",
-        }
-
-        creds = {}
-        for key, env in cred_mapping.items():
-            value = self.get_option(key) or os.getenv(env)
-            if value:
-                if key == "cloud":
-                    self._verify_cloud(value)
-                    creds["base_url"] = value
-                else:
-                    creds[key] = value
-
-        # Make sure we have client_id and client_secret
-        if "client_id" not in creds or "client_secret" not in creds:
-            raise AnsibleError(
-                "You must provide a client_id and client_secret to authenticate to the Falcon API."
-            )
-
-        return creds
-
-    def _verify_cloud(self, cloud):
-        """Verify the cloud region."""
-        valid_clouds = ["us-1", "us-2", "eu-1", "us-gov-1"]
-        if cloud not in valid_clouds:
-            raise AnsibleError(
-                f"Invalid cloud region: '{cloud}'. Valid values are {', '.join(valid_clouds)}"
-            )
-
     def _authenticate(self):
         """Authenticate to the CrowdStrike Falcon API."""
-        creds = self._credential_setup()
-
-        return Hosts(**creds)
+        return authenticate(Hosts, self.get_option)
 
     def _get_device_ids(self, falcon, term):
         """Fetch host IDs based on the provided filter expression."""
@@ -152,7 +118,6 @@ class LookupModule(LookupBase):
             else:
                 return host_ids
 
-            # Check if we need to continue
             offset = host_lookup["body"]["meta"]["pagination"]["offset"]
             if host_lookup["body"]["meta"]["pagination"]["total"] <= len(host_ids):
                 running = False
@@ -161,18 +126,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
         """Fetch host IDs based on the provided filter expression."""
-
-        # Check if the 'falconpy' library is installed
-        if not HAS_FALCONPY:
-            raise AnsibleError(
-                "The 'crowdstrike.falcon.host_ids' lookup cannot be run because the 'falconpy' library is not installed."
-            )
-
-        # Check if the 'falconpy' library is compatible
-        if _VERSION < "1.3.0":
-            raise AnsibleError(
-                f"Unsupported FalconPy version: {_VERSION}. Upgrade to 1.3.0 or higher."
-            )
+        check_falconpy("crowdstrike.falcon.host_ids")
 
         self.set_options(var_options=variables, direct=kwargs)
 
@@ -182,10 +136,11 @@ class LookupModule(LookupBase):
         for term in terms:
             display.debug(f"Fetching host IDs with filter expression: {term}")
             try:
-                # Fetch host IDs based on the provided filter expression
                 display.vvv(f"FQL Filter used: {term}")
                 ret.append(self._get_device_ids(falcon, term))
-            except Exception as e:  # pylint: disable=broad-except
+            except AnsibleError:
+                raise
+            except Exception as e:
                 raise AnsibleError(f"Failed to fetch host IDs: {e}") from e
 
         return ret

--- a/plugins/plugin_utils/__init__.py
+++ b/plugins/plugin_utils/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared utilities for CrowdStrike Falcon plugins."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type

--- a/plugins/plugin_utils/falconpy_utils.py
+++ b/plugins/plugin_utils/falconpy_utils.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared FalconPy utilities for lookup and inventory plugins."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+import traceback
+
+from ansible.errors import AnsibleError
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy._version import _VERSION
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    _VERSION = None
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+MINIMUM_FALCONPY_VERSION = "1.3.0"
+VALID_CLOUDS = ["us-1", "us-2", "eu-1", "us-gov-1", "us-gov-2"]
+
+
+def check_falconpy(plugin_name):
+    """Verify FalconPy is installed and meets minimum version requirements.
+
+    Args:
+        plugin_name: Name of the plugin for error messages (e.g., 'crowdstrike.falcon.host_ids')
+
+    Raises:
+        AnsibleError: If FalconPy is not installed or version is too old
+    """
+    if not HAS_FALCONPY:
+        raise AnsibleError(
+            f"The '{plugin_name}' lookup cannot be run because the 'crowdstrike-falconpy' "
+            "library is not installed."
+        )
+
+    if _VERSION < MINIMUM_FALCONPY_VERSION:
+        raise AnsibleError(
+            f"Unsupported FalconPy version: {_VERSION}. "
+            f"Upgrade to {MINIMUM_FALCONPY_VERSION} or higher."
+        )
+
+
+def get_falconpy_credentials(get_option_func):
+    """Setup credentials for FalconPy from plugin options or environment variables.
+
+    Args:
+        get_option_func: A callable that retrieves plugin options (e.g., self.get_option)
+
+    Returns:
+        dict: Credential dictionary suitable for FalconPy service class initialization
+
+    Raises:
+        AnsibleError: If required credentials are missing or cloud region is invalid
+    """
+    cred_mapping = {
+        "client_id": "FALCON_CLIENT_ID",
+        "client_secret": "FALCON_CLIENT_SECRET",
+        "member_cid": "FALCON_MEMBER_CID",
+        "cloud": "FALCON_CLOUD",
+    }
+
+    creds = {}
+    for key, env in cred_mapping.items():
+        value = get_option_func(key) or os.getenv(env)
+        if value:
+            if key == "cloud":
+                if value not in VALID_CLOUDS:
+                    raise AnsibleError(
+                        f"Invalid cloud region: '{value}'. Valid values are {', '.join(VALID_CLOUDS)}"
+                    )
+                creds["base_url"] = value
+            else:
+                creds[key] = value
+
+    if "client_id" not in creds or "client_secret" not in creds:
+        raise AnsibleError(
+            "You must provide a client_id and client_secret to authenticate to the Falcon API."
+        )
+
+    return creds
+
+
+def validate_authentication(falcon):
+    """Validate that authentication to the Falcon API was successful.
+
+    Args:
+        falcon: A FalconPy service class instance
+
+    Raises:
+        AnsibleError: If authentication failed with details about the failure
+    """
+    if not falcon.auth_object.token_valid:
+        raise AnsibleError(
+            f"Unable to authenticate to the CrowdStrike Falcon API: "
+            f"{falcon.auth_object.token_fail_reason}"
+        )
+
+
+def authenticate(service_class, get_option_func):
+    """Authenticate to the CrowdStrike Falcon API and validate the connection.
+
+    Args:
+        service_class: The FalconPy service class to instantiate (e.g., Hosts, SensorUpdatePolicy)
+        get_option_func: A callable that retrieves plugin options (e.g., self.get_option)
+
+    Returns:
+        An authenticated instance of the service class
+
+    Raises:
+        AnsibleError: If credentials are invalid or authentication fails
+    """
+    creds = get_falconpy_credentials(get_option_func)
+    falcon = service_class(**creds)
+    validate_authentication(falcon)
+    return falcon

--- a/tests/lookup-test.yml
+++ b/tests/lookup-test.yml
@@ -1,0 +1,212 @@
+---
+# Test playbook for CrowdStrike Falcon lookup plugins
+#
+# This playbook tests the following lookup plugins:
+#   - crowdstrike.falcon.host_ids
+#   - crowdstrike.falcon.maintenance_token
+#   - crowdstrike.falcon.fctl_child_cids (requires Flight Control)
+#
+# Required environment variables:
+#   - FALCON_CLIENT_ID: CrowdStrike API client ID
+#   - FALCON_CLIENT_SECRET: CrowdStrike API client secret
+#   - FALCON_CLOUD: (optional) CrowdStrike cloud region (us-1, us-2, eu-1, us-gov-1, us-gov-2)
+#
+# Usage:
+#   ansible-playbook tests/lookup-test.yml -v
+#
+- name: Test CrowdStrike Falcon lookup plugins
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Test filters for host_ids lookup
+    test_filter_windows: 'platform_name:"Windows"'
+    test_filter_linux: 'platform_name:"Linux"'
+    test_limit_filter: 'platform_name:"Windows"'
+
+  tasks:
+    # =========================================================================
+    # Prerequisite: Verify credentials are available
+    # =========================================================================
+    - name: Verify FALCON_CLIENT_ID is set
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'FALCON_CLIENT_ID') | length > 0
+        fail_msg: "FALCON_CLIENT_ID environment variable must be set"
+        success_msg: "FALCON_CLIENT_ID is configured"
+
+    - name: Verify FALCON_CLIENT_SECRET is set
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'FALCON_CLIENT_SECRET') | length > 0
+        fail_msg: "FALCON_CLIENT_SECRET environment variable must be set"
+        success_msg: "FALCON_CLIENT_SECRET is configured"
+
+    # =========================================================================
+    # Test: host_ids lookup plugin
+    # =========================================================================
+    - name: Test host_ids lookup - fetch all hosts (empty filter)
+      tags:
+        - host_ids
+        - all_hosts
+      block:
+        - name: Fetch all host IDs
+          ansible.builtin.set_fact:
+            all_host_ids: "{{ lookup('crowdstrike.falcon.host_ids', '') }}"
+
+        - name: Display host count
+          ansible.builtin.debug:
+            msg: "Found {{ all_host_ids | length }} hosts in the environment"
+
+        - name: Verify host_ids returns a list
+          ansible.builtin.assert:
+            that:
+              - all_host_ids is defined
+              - all_host_ids is iterable
+            success_msg: "host_ids lookup returned valid list"
+
+    - name: Test host_ids lookup - fetch with platform filter
+      tags:
+        - host_ids
+        - filtered
+      block:
+        - name: Fetch Windows host IDs
+          ansible.builtin.set_fact:
+            windows_host_ids: "{{ lookup('crowdstrike.falcon.host_ids', test_filter_windows) }}"
+
+        - name: Display Windows host count
+          ansible.builtin.debug:
+            msg: "Found {{ windows_host_ids | length }} Windows hosts"
+
+        - name: Fetch Linux host IDs
+          ansible.builtin.set_fact:
+            linux_host_ids: "{{ lookup('crowdstrike.falcon.host_ids', test_filter_linux) }}"
+
+        - name: Display Linux host count
+          ansible.builtin.debug:
+            msg: "Found {{ linux_host_ids | length }} Linux hosts"
+
+    - name: Test host_ids lookup - multiple filters in single call
+      tags:
+        - host_ids
+        - multi_filter
+      block:
+        - name: Fetch hosts with multiple filter terms
+          ansible.builtin.set_fact:
+            multi_filter_results: "{{ lookup('crowdstrike.falcon.host_ids', test_filter_windows, test_filter_linux) }}"
+
+        - name: Verify multiple filter results
+          ansible.builtin.debug:
+            msg: "Multi-filter lookup returned {{ multi_filter_results | length }} result sets"
+
+    # =========================================================================
+    # Test: maintenance_token lookup plugin
+    # =========================================================================
+    - name: Test maintenance_token lookup - bulk token
+      tags:
+        - maintenance_token
+        - bulk
+      block:
+        - name: Fetch bulk maintenance token
+          ansible.builtin.set_fact:
+            bulk_token: "{{ lookup('crowdstrike.falcon.maintenance_token', bulk=true) }}"
+
+        - name: Verify bulk token was retrieved
+          ansible.builtin.assert:
+            that:
+              - bulk_token is defined
+              - bulk_token | length > 0
+            success_msg: "Successfully retrieved bulk maintenance token"
+
+        - name: Display bulk token (masked)
+          ansible.builtin.debug:
+            msg: "Bulk token retrieved: {{ bulk_token[:4] }}...{{ bulk_token[-4:] }}"
+
+    - name: Test maintenance_token lookup - specific host token
+      when: all_host_ids | default([]) | length > 0
+      tags:
+        - maintenance_token
+        - host_specific
+      block:
+        - name: Get first host ID for testing
+          ansible.builtin.set_fact:
+            test_host_id: "{{ all_host_ids[0] }}"
+
+        - name: Fetch maintenance token for specific host
+          ansible.builtin.set_fact:
+            host_token: "{{ lookup('crowdstrike.falcon.maintenance_token', test_host_id) }}"
+
+        - name: Verify host-specific token was retrieved
+          ansible.builtin.assert:
+            that:
+              - host_token is defined
+              - host_token | length > 0
+            success_msg: "Successfully retrieved maintenance token for host {{ test_host_id }}"
+
+        - name: Display host token (masked)
+          ansible.builtin.debug:
+            msg: "Host token for {{ test_host_id }}: {{ host_token[:4] }}...{{ host_token[-4:] }}"
+
+    # =========================================================================
+    # Test: fctl_child_cids lookup plugin (Flight Control - MSSP only)
+    # =========================================================================
+    - name: Test fctl_child_cids lookup (Flight Control)
+      tags:
+        - fctl_child_cids
+        - flight_control
+      block:
+        - name: Attempt to fetch Flight Control child CIDs
+          ansible.builtin.set_fact:
+            child_cids: "{{ lookup('crowdstrike.falcon.fctl_child_cids') }}"
+
+        - name: Display child CID count
+          ansible.builtin.debug:
+            msg: "Found {{ child_cids | length }} Flight Control child CIDs"
+
+        - name: Verify fctl_child_cids returns a list
+          ansible.builtin.assert:
+            that:
+              - child_cids is defined
+              - child_cids is iterable
+            success_msg: "fctl_child_cids lookup returned valid list"
+      rescue:
+        - name: Flight Control not available
+          ansible.builtin.debug:
+            msg: >-
+              Flight Control lookup failed - this is expected if your API credentials
+              do not have Flight Control scope or you are not an MSSP.
+              Error details are logged above.
+
+    # =========================================================================
+    # Test: Error handling - invalid credentials
+    # =========================================================================
+    - name: Test authentication error handling
+      tags:
+        - error_handling
+        - never
+      block:
+        - name: Attempt lookup with invalid cloud region
+          ansible.builtin.set_fact:
+            bad_result: "{{ lookup('crowdstrike.falcon.host_ids', '', cloud='invalid-cloud') }}"
+
+        - name: This should not be reached
+          ansible.builtin.fail:
+            msg: "Expected AnsibleError for invalid cloud region"
+      rescue:
+        - name: Verify proper error was raised
+          ansible.builtin.debug:
+            msg: "Correctly received error for invalid cloud region"
+
+    # =========================================================================
+    # Summary
+    # =========================================================================
+    - name: Test summary
+      tags:
+        - summary
+      ansible.builtin.debug:
+        msg:
+          - "===== Lookup Plugin Test Summary ====="
+          - "host_ids: {{ all_host_ids | default([]) | length }} hosts found"
+          - "maintenance_token (bulk): {{ 'Retrieved' if bulk_token | default('') | length > 0 else 'Not tested' }}"
+          - "fctl_child_cids: {{ child_cids | default([]) | length }} child CIDs found"


### PR DESCRIPTION
## Summary

Adds early OAuth authentication validation to lookup plugins and refactors shared code into a centralized utility module.

**Addresses #664** - Authentication errors now fail immediately with clear messages instead of surfacing as confusing 401/403 errors on subsequent API calls.

## Changes

- **New**: `plugins/plugin_utils/falconpy_utils.py` - Shared authentication utilities
  - `check_falconpy()` - Validates library installation and version requirements
  - `get_falconpy_credentials()` - Handles credential setup from options/environment
  - `validate_authentication()` - Checks OAuth token validity using public FalconPy API
  - `authenticate()` - Combines all auth steps with early validation

- **Refactored**: `host_ids`, `maintenance_token`, `fctl_child_cids` lookup plugins
  - Use shared utilities (DRY compliance)
  - ~50% code reduction per plugin
  - Consistent error handling across all plugins

- **New**: `us-gov-2` added to valid cloud regions

- **New**: `tests/lookup-test.yml` - Integration test playbook for lookup plugins

## Technical Details

Uses public FalconPy properties for authentication validation:
```python
if not falcon.auth_object.token_valid:
    raise AnsibleError(f"Unable to authenticate: {falcon.auth_object.token_fail_reason}")
```

This replaces the approach in #664 which accessed private attributes (`_token._status`).