### PR TITLE
fix(modules): pass correct argument to handle_return_errors

### DIFF
--- a/changelogs/fragments/666-fix-host-hide-host-contain-handle-return-errors.yml
+++ b/changelogs/fragments/666-fix-host-hide-host-contain-handle-return-errors.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - >-
+    host_hide module - Fix TypeError when calling handle_return_errors
+    with wrong argument type
+    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/666).
+  - >-
+    host_contain module - Fix TypeError when calling handle_return_errors
+    with wrong argument type
+    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/666).

--- a/plugins/modules/host_contain.py
+++ b/plugins/modules/host_contain.py
@@ -204,7 +204,7 @@ def main():
 
     # If we get nothing back, handle the error
     if not good and not bad:
-        handle_return_errors(module, falcon, query_result)
+        handle_return_errors(module, result, query_result)
 
     # Create a mapping for passed-in host IDs to manage their states
     host_mapping = {host_id: "" for host_id in hosts}

--- a/plugins/modules/host_hide.py
+++ b/plugins/modules/host_hide.py
@@ -202,7 +202,7 @@ def process_hosts(module, falcon, action_name, hosts, result):
 
     # If we get nothing back, handle the error
     if not good and not bad:
-        handle_return_errors(module, falcon, query_result)
+        handle_return_errors(module, result, query_result)
 
     # Create a mapping for passed-in host IDs to manage their states
     host_mapping = {host_id: "" for host_id in hosts}


### PR DESCRIPTION
## Summary
- Fix TypeError in `host_hide` and `host_contain` modules where `falcon` (FalconPy Hosts service object) was passed to `handle_return_errors()` instead of `result` (dict)
- This caused `TypeError: 'Hosts' object does not support item assignment` when the API returned neither successful nor failed hosts

Closes #666

## Changes
- `plugins/modules/host_hide.py`: Change line 205 from `handle_return_errors(module, falcon, query_result)` to `handle_return_errors(module, result, query_result)`
- `plugins/modules/host_contain.py`: Change line 207 from `handle_return_errors(module, falcon, query_result)` to `handle_return_errors(module, result, query_result)`
- Added changelog fragment