### PR TITLE
fix(modules): sanitize sensor_version to remove LTS suffix

### DIFF
--- a/changelogs/fragments/lts-version-suffix-fix.yml
+++ b/changelogs/fragments/lts-version-suffix-fix.yml
@@ -1,0 +1,13 @@
+---
+bugfixes:
+  - >-
+    sensor_update_policy_info module - Sanitize sensor_version fields to remove LTS suffix
+    that causes sensor download API failures
+    (https://github.com/CrowdStrike/falcon-scripts/issues/460).
+  - >-
+    sensor_update_builds_info module - Sanitize sensor_version fields to remove LTS suffix
+    that causes sensor download API failures
+    (https://github.com/CrowdStrike/falcon-scripts/issues/460).
+  - >-
+    sensor_update_policy_info module - Fix NoneType error when policy variants field is null
+    (https://github.com/CrowdStrike/falcon-scripts/issues/460).

--- a/plugins/module_utils/falconpy_utils.py
+++ b/plugins/module_utils/falconpy_utils.py
@@ -145,6 +145,24 @@ def get_paginated_results_info(module, args, limit, method, list_name):
     return result
 
 
+def sanitize_sensor_version(version):
+    """
+    Sanitize a sensor version string by removing any suffix (e.g., LTS designation).
+
+    The sensor update policy API may return versions with suffixes like "(LTS)".
+    The sensor download API requires clean version numbers without suffixes.
+
+    Args:
+        version: Version string (e.g., "7.32.20403 (LTS)" or "7.32.20403")
+
+    Returns:
+        Clean version string (e.g., "7.32.20403")
+    """
+    if not version or not isinstance(version, str):
+        return version
+    return version.split(" ")[0]
+
+
 def get_cloud_from_url(module, base_url):
     """Return the cloud name from a base URL."""
     mapping = {

--- a/plugins/modules/sensor_update_builds_info.py
+++ b/plugins/modules/sensor_update_builds_info.py
@@ -103,6 +103,7 @@ from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils 
     authenticate,
     check_falconpy_version,
     handle_return_errors,
+    sanitize_sensor_version,
 )
 
 FALCONPY_IMPORT_ERROR = None
@@ -165,9 +166,12 @@ def main():
     )
 
     if query_result["status_code"] == 200:
-        result.update(
-            builds=query_result["body"]["resources"],
-        )
+        builds = query_result["body"]["resources"]
+        # Sanitize sensor_version fields to handle LTS suffixes
+        for build in builds:
+            if "sensor_version" in build:
+                build["sensor_version"] = sanitize_sensor_version(build["sensor_version"])
+        result.update(builds=builds)
 
     handle_return_errors(module, result, query_result)
 


### PR DESCRIPTION
## Summary

- Adds `sanitize_sensor_version()` utility function to strip suffixes like "(LTS)" from version strings
- Applies sanitization to `sensor_update_policy_info` and `sensor_update_builds_info` modules
- Fixes NoneType error when policy variants field is null

## Changes

- `plugins/module_utils/falconpy_utils.py`: New `sanitize_sensor_version()` function
- `plugins/modules/sensor_update_policy_info.py`: Sanitize versions in policy settings and variants
- `plugins/modules/sensor_update_builds_info.py`: Sanitize versions in build results
- `changelogs/fragments/lts-version-suffix-fix.yml`: Changelog entry