### PR TITLE
fix(falcon_install): correct falcon_os_version for Amazon Linux 2 arm64

### DIFF
--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -56,6 +56,11 @@ jobs:
             image_arch: x86_64
             image_name: amzn2-ami-hvm-2.0*gp2
             instance_type: t2.micro
+          - distro: amazon-2-arm
+            image_owner: '137112412989'
+            image_arch: arm64
+            image_name: amzn2-ami-hvm-2.0*gp2
+            instance_type: t4g.micro
           - distro: sles-15-sp5
             image_owner: '013907871322'
             image_arch: x86_64

--- a/changelogs/fragments/682-al2-arm64-os-version.yml
+++ b/changelogs/fragments/682-al2-arm64-os-version.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    falcon_install role - Fix incorrect falcon_os_version for Amazon Linux 2 arm64
+    by setting the API-expected value '2 - arm64' for aarch64 architecture
+    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/682).

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -43,7 +43,7 @@
 
 - name: "CrowdStrike Falcon | Override OS version for Amazon Linux 2"
   ansible.builtin.set_fact:
-    falcon_os_version: "{{ ansible_facts['distribution_major_version'] }}"
+    falcon_os_version: "{{ '2 - arm64' if ansible_facts['architecture'] == 'aarch64' else '2' }}"
   when:
     - ansible_facts['distribution'] == "Amazon"
     - ansible_facts['distribution_major_version'] | int == 2


### PR DESCRIPTION
The CrowdStrike sensor downloads API uses architecture-dependent `os_version` values for Amazon Linux 2:
- **x86_64**: `os_version` = `2`
- **arm64**: `os_version` = `2 - arm64`

The existing code unconditionally set `falcon_os_version` to `"2"` for all Amazon Linux 2 systems, which caused sensor download failures on arm64 hosts. Wildcards (`*2*`) can't be used because they'd also match Amazon Linux 2023.

This updates the `set_fact` in `preinstall.yml` to check `ansible_facts['architecture']` and set the correct value per arch. x86_64 behavior is unchanged.

Also adds an `amazon-2-arm` entry to the CI test matrix so arm64 gets coverage going forward.

Closes #682