### PR TITLE
fix(falcon_install): use internal variable for sensor version filter

### DIFF
--- a/changelogs/fragments/679-fix-sensor-version-extra-vars.yml
+++ b/changelogs/fragments/679-fix-sensor-version-extra-vars.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - falcon_install role - Fix malformed API filter when ``falcon_sensor_version`` is passed via extra args (https://github.com/CrowdStrike/ansible_collection_falcon/issues/679)

--- a/roles/falcon_install/tasks/api.yml
+++ b/roles/falcon_install/tasks/api.yml
@@ -39,9 +39,9 @@
         falcon_sensor_update_policy_package_version: "{{ falcon_sensor_update_policy_info.policies[0].settings.variants[0].sensor_version }}"
       when: ansible_facts['machine'] | default('') == "aarch64"
 
-    - name: CrowdStrike Falcon | Override falcon_sensor_version with version from Sensor Update Policy
+    - name: CrowdStrike Falcon | Build falcon_sensor_version_filter from Sensor Update Policy
       ansible.builtin.set_fact:
-        falcon_sensor_version: "+version:'{{ falcon_sensor_update_policy_package_version }}'"
+        falcon_sensor_version_filter: "+version:'{{ falcon_sensor_update_policy_package_version }}'"
 
 - name: "CrowdStrike Falcon | Build API Sensor Query"
   ansible.builtin.set_fact:
@@ -49,7 +49,7 @@
       os:'{{ falcon_target_os }}'+
       os_version:'{{ falcon_os_version }}'{{
       falcon_os_arch | default('') }}{{
-      falcon_sensor_version | default('') }}
+      falcon_sensor_version_filter | default('') }}
 
 - name: CrowdStrike Falcon | Get list of filtered Falcon sensors
   crowdstrike.falcon.sensor_download_info:

--- a/roles/falcon_install/tasks/preinstall.yml
+++ b/roles/falcon_install/tasks/preinstall.yml
@@ -125,9 +125,9 @@
     falcon_sensor_version_decrement: 0
   when: (falcon_sensor_update_policy_name | length > 0) or (falcon_sensor_version | length > 0)
 
-- name: CrowdStrike Falcon | Override falcon_sensor_version when set
+- name: CrowdStrike Falcon | Build falcon_sensor_version_filter when falcon_sensor_version is set
   ansible.builtin.set_fact:
-    falcon_sensor_version: "+version:'{{ falcon_sensor_version }}'"
+    falcon_sensor_version_filter: "+version:'{{ falcon_sensor_version }}'"
   when: falcon_sensor_version | length > 0
 
 - name: CrowdStrike Falcon | Check if sensor is already installed


### PR DESCRIPTION
When `falcon_sensor_version` is passed via extra args (`-e`), Ansible's variable precedence causes `set_fact` to be overridden, producing a malformed API filter query like `os:'Linux'+os_version:'*8*'7.34.18708` instead of the expected `os:'Linux'+os_version:'*8*'+version:'7.34.18708'`.

This introduces an internal `falcon_sensor_version_filter` variable to hold the transformed FQL string, so the original extra var value is never overwritten.

### Changes
- `preinstall.yml` — write to `falcon_sensor_version_filter` instead of overwriting `falcon_sensor_version`
- `api.yml` — same change for the Sensor Update Policy path, and reference the new variable in the query builder

Closes #679