### PR TITLE
feat: bump minimum ansible-core to 2.16 and Python to 3.12

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -6,7 +6,7 @@ pylint
 pre-commit
 autopep8
 ansible
-ansible-core==2.16.7
+ansible-core==2.18.3
 ansible-lint
 boto3
 botocore

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/falcon_configure.yml
+++ b/.github/workflows/falcon_configure.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/falcon_configure_remove_aid.yml
+++ b/.github/workflows/falcon_configure_remove_aid.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/falcon_install.yml
+++ b/.github/workflows/falcon_install.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/falcon_uninstall.yml
+++ b/.github/workflows/falcon_uninstall.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-          python-version: '3.11'
+          python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Build docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/win_falcon_configure.yml
+++ b/.github/workflows/win_falcon_configure.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/win_falcon_install.yml
+++ b/.github/workflows/win_falcon_install.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/.github/workflows/win_falcon_uninstall.yml
+++ b/.github/workflows/win_falcon_uninstall.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: '.devcontainer/requirements.txt'
 

--- a/changelogs/fragments/bump-ansible-core-2.16-python-3.12.yml
+++ b/changelogs/fragments/bump-ansible-core-2.16-python-3.12.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - The minimum supported version of ansible-core has been bumped from 2.15 to 2.16 and Python from 3.6 to 3.12.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -8,7 +8,7 @@ modules:
   # Configuration for modules/module_utils.
   # These settings do not apply to other content in the collection.
 
-  python_requires: ">=3.6"
+  python_requires: ">=3.12"
   # Python versions supported by modules/module_utils.
   # This setting is required.
   #

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,5 +1,0 @@
-plugins/modules/falconctl.py compile-2.6!skip
-plugins/modules/falconctl_info.py compile-2.6!skip
-plugins/module_utils/falconctl_utils.py compile-2.6!skip
-plugins/modules/falconctl.py import-2.6!skip
-plugins/modules/falconctl_info.py import-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,6 +1,0 @@
-plugins/modules/falconctl.py compile-2.6!skip
-plugins/modules/falconctl_info.py compile-2.6!skip
-plugins/module_utils/falconctl_utils.py compile-2.6!skip
-plugins/modules/falconctl.py import-2.6!skip
-plugins/modules/falconctl_info.py import-2.6!skip
-plugins/module_utils/falconctl_utils.py import-2.6!skip

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,7 +1,0 @@
-plugins/modules/falconctl.py compile-2.6!skip
-plugins/modules/falconctl_info.py compile-2.6!skip
-plugins/module_utils/falconctl_utils.py compile-2.6!skip
-plugins/modules/falconctl.py import-2.6!skip
-plugins/modules/falconctl_info.py import-2.6!skip
-plugins/module_utils/falconctl_utils.py import-2.6!skip
-extensions/eda/plugins/event_source/eventstream.py pylint:unknown-option-value

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,7 +1,0 @@
-plugins/modules/falconctl.py compile-2.6!skip
-plugins/modules/falconctl_info.py compile-2.6!skip
-plugins/module_utils/falconctl_utils.py compile-2.6!skip
-plugins/modules/falconctl.py import-2.6!skip
-plugins/modules/falconctl_info.py import-2.6!skip
-plugins/module_utils/falconctl_utils.py import-2.6!skip
-extensions/eda/plugins/event_source/eventstream.py pylint:unknown-option-value

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,1 +1,0 @@
-extensions/eda/plugins/event_source/eventstream.py pylint:unknown-option-value


### PR DESCRIPTION
Red Hat is updating Ansible Automation Platform (AAP) certification requirements effective May 18, 2026. Certified collections must target **ansible-core 2.16** as the minimum supported version and be tested against **Python 3.12**. This PR updates the collection to meet those requirements.

### Why this is needed

AAP-certified collections that still declare `requires_ansible: ">=2.15.0"` or test against older Python versions will fail certification after the cutoff date. Ansible Core 2.15 is reaching end-of-life and will no longer be included in AAP test matrices.

### What changed

- **`meta/runtime.yml`** — bumped `requires_ansible` from `>=2.15.0` to `>=2.16.0`
- **`tests/config.yml`** — bumped `python_requires` from `>=3.6` to `>=3.12`
- **`.devcontainer/requirements.txt`** — bumped `ansible-core` from `2.16.7` to `2.18.3`
- **11 CI/CD workflows** — updated `python-version` to `3.12` (from `3.11` or `3.8`)
- **Removed old sanity ignore files** — deleted `ignore-2.11.txt` through `ignore-2.15.txt` (no longer relevant)
- **Changelog fragment** added