### PR TITLE
release: 4.11.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Ansible CrowdStrike Falcon Collection Release Notes
 
 .. contents:: Topics
 
+v4.11.1
+=======
+
+Release Summary
+---------------
+
+| Release Date: 2026-03-09
+| `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.11.1>`__
+
+Bugfixes
+--------
+
+- falcon_install role - Fix ``ansible_facts['machine']`` undefined error on Windows hosts when using Sensor Update Policy (https://github.com/CrowdStrike/ansible_collection_falcon/issues/680)
+- falcon_install role - Fix incorrect falcon_os_version for Amazon Linux 2 arm64 by setting the API-expected value '2 - arm64' for aarch64 architecture (https://github.com/CrowdStrike/ansible_collection_falcon/issues/682).
+- falcon_install role - Fix malformed API filter when ``falcon_sensor_version`` is passed via extra args (https://github.com/CrowdStrike/ansible_collection_falcon/issues/679)
+
 v4.11.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -560,6 +560,27 @@ releases:
       - 4.11.0.yml
       - lts-version-suffix-fix.yml
     release_date: '2026-01-29'
+  4.11.1:
+    changes:
+      bugfixes:
+        - falcon_install role - Fix ``ansible_facts['machine']`` undefined error on
+          Windows hosts when using Sensor Update Policy (https://github.com/CrowdStrike/ansible_collection_falcon/issues/680)
+        - falcon_install role - Fix incorrect falcon_os_version for Amazon Linux 2
+          arm64 by setting the API-expected value '2 - arm64' for aarch64 architecture
+          (https://github.com/CrowdStrike/ansible_collection_falcon/issues/682).
+        - falcon_install role - Fix malformed API filter when ``falcon_sensor_version``
+          is passed via extra args (https://github.com/CrowdStrike/ansible_collection_falcon/issues/679)
+      release_summary: '| Release Date: 2026-03-09
+
+        | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.11.1>`__
+
+        '
+    fragments:
+      - 4.11.1.yml
+      - 679-fix-sensor-version-extra-vars.yml
+      - 680-fix-windows-machine-fact.yml
+      - 682-al2-arm64-os-version.yml
+    release_date: '2026-03-09'
   4.2.0:
     changes:
       minor_changes:

--- a/changelogs/fragments/679-fix-sensor-version-extra-vars.yml
+++ b/changelogs/fragments/679-fix-sensor-version-extra-vars.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - falcon_install role - Fix malformed API filter when ``falcon_sensor_version`` is passed via extra args (https://github.com/CrowdStrike/ansible_collection_falcon/issues/679)

--- a/changelogs/fragments/680-fix-windows-machine-fact.yml
+++ b/changelogs/fragments/680-fix-windows-machine-fact.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - falcon_install role - Fix ``ansible_facts['machine']`` undefined error on Windows hosts when using Sensor Update Policy (https://github.com/CrowdStrike/ansible_collection_falcon/issues/680)

--- a/changelogs/fragments/682-al2-arm64-os-version.yml
+++ b/changelogs/fragments/682-al2-arm64-os-version.yml
@@ -1,6 +1,0 @@
----
-bugfixes:
-  - >-
-    falcon_install role - Fix incorrect falcon_os_version for Amazon Linux 2 arm64
-    by setting the API-expected value '2 - arm64' for aarch64 architecture
-    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/682).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 4.11.0
+version: 4.11.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Patch release with three bugfixes for the `falcon_install` role:

- Fix malformed API filter when `falcon_sensor_version` is passed via extra args (#679)
- Fix `ansible_facts['machine']` undefined error on Windows hosts (#680)
- Fix incorrect `falcon_os_version` for Amazon Linux 2 arm64 (#682)

> **Note:** Merge after #686.