### PR TITLE
fix(eda): ensure token refresh on quiet event streams

### DIFF
--- a/changelogs/fragments/691-fix-eda-eventstream-token-refresh.yml
+++ b/changelogs/fragments/691-fix-eda-eventstream-token-refresh.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - eventstream event source - Fix token refresh never triggering on quiet streams by polling with a timeout instead of blocking indefinitely (https://github.com/CrowdStrike/ansible_collection_falcon/issues/691).

--- a/extensions/eda/plugins/event_source/eventstream.py
+++ b/extensions/eda/plugins/event_source/eventstream.py
@@ -69,7 +69,7 @@ EXAMPLES = r"""
         stream_name: eda
         latest: true
         include_event_types:
-          - EPPDetectionSummaryEvent
+          - EppDetectionSummaryEvent
 """
 
 RETURN = r"""
@@ -99,6 +99,10 @@ REGIONS: dict[str, str] = {
 
 # Keep this in sync with galaxy.yml
 VERSION = "4.2.1"
+
+# Maximum seconds to wait for stream data before checking token expiry.
+# Ensures timely token refresh even when no events or heartbeats arrive.
+_STREAM_POLL_INTERVAL = 30
 
 
 class AIOFalconAPI:
@@ -262,6 +266,11 @@ class AIOFalconAPI:
             "Content-Type": "application/json",
         }
         async with self.session.post(url, headers=headers, params=params) as resp:
+            if resp.status != ok_response:
+                logger.warning(
+                    "Failed to refresh stream session (HTTP %s)",
+                    resp.status,
+                )
             return resp.status == ok_response
 
 
@@ -416,25 +425,40 @@ class Stream:
         """
         # Open the stream
         await self.open_stream()
-        # Asynchronously iterate over the lines in the stream
-        async for line in self.spigot.content:
-            # Decode the line from bytes to a string and remove trailing whitespace
+        # Poll for data with a timeout so token refresh is never starved
+        while True:
+            try:
+                line = await asyncio.wait_for(
+                    self.spigot.content.readline(),
+                    timeout=_STREAM_POLL_INTERVAL,
+                )
+            except TimeoutError:
+                # No data arrived — check if a token refresh is needed
+                if self.token_expired():
+                    refresh = await self.refresh()
+                    if not refresh:
+                        msg = "Failed to refresh token."
+                        raise ValueError(msg) from None
+                continue
+
+            # EOF — server closed the connection
+            if not line:
+                break
+
             decoded_line = line.decode().rstrip()
             if decoded_line:
-                # Load the event as a JSON object
                 json_event = json.loads(decoded_line)
                 event_type = json_event["metadata"]["eventType"]
                 self.offset = json_event["metadata"]["offset"]
-                # If the event is valid, yield it
                 if self.is_valid_event(event_type, exclude_event_types):
                     yield {"falcon": json_event}
-            # If the token has expired, refresh it and reopen the stream
+
+            # Check after every received line as well
             if self.token_expired():
                 refresh = await self.refresh()
-                if refresh:
-                    continue
-                msg = "Failed to refresh token."
-                raise ValueError(msg)
+                if not refresh:
+                    msg = "Failed to refresh token."
+                    raise ValueError(msg)
 
     def is_valid_event(
         self: "Stream",

--- a/extensions/eda/rulebooks/event_stream_example.yml
+++ b/extensions/eda/rulebooks/event_stream_example.yml
@@ -5,14 +5,17 @@
     - crowdstrike.falcon.eventstream:
         falcon_client_id: "{{ FALCON_CLIENT_ID }}"
         falcon_client_secret: "{{ FALCON_CLIENT_SECRET }}"
-        falcon_cloud: "us-2"
-        # offset: 12345
+        falcon_cloud: "us-1"
+        # latest = true will always start from the latest entry.
+        # If you want to start from an offset, use offset instead.
+        # If you want to start from the beginning, set latest = false
+        latest: true
         stream_name: "eda-example"
         include_event_types:
-          - "DetectionSummaryEvent"
+          - EppDetectionSummaryEvent
 
   rules:
     - name: Print High and Critical Severity Detection Events
-      condition: event.falcon.event.Severity > 3
+      condition: event.falcon.event.Severity >= 60
       action:
         debug:


### PR DESCRIPTION
Fixes a bug where the EDA eventstream plugin stops receiving events after the server-side session expires (~30 minutes) on quiet streams.

The `async for line in self.spigot.content:` loop blocks indefinitely when no data arrives, so `token_expired()` never executes. This replaces it with a timeout-based polling loop (`asyncio.wait_for` with a 30s ceiling) that guarantees the token check runs regularly regardless of event flow.

Also:
- Adds a warning log when stream refresh gets a non-200 response
- Fixes `EPPDetectionSummaryEvent` → `EppDetectionSummaryEvent` casing in plugin examples
- Updates the example rulebook with correct event types and helpful comments

Closes #691