### PR TITLE
Bump v4.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,27 @@ Ansible CrowdStrike Falcon Collection Release Notes
 
 .. contents:: Topics
 
+v4.12.0
+=======
+
+Release Summary
+---------------
+
+| Release Date: 2026-05-17
+| `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.12.0>`__
+
+Minor Changes
+-------------
+
+- correlation_rule module - New module to create, update, and delete NG-SIEM correlation rules (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).
+- correlation_rule_info module - New module to query and retrieve NG-SIEM correlation rule information (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).
+
+New Modules
+-----------
+
+- crowdstrike.falcon.correlation_rule - Manage NG\-SIEM correlation rules
+- crowdstrike.falcon.correlation_rule_info - Get information about NG\-SIEM correlation rules
+
 v4.11.2
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -613,6 +613,29 @@ releases:
       - 693-fix-eda-eventstream-reconnect-cleanup.yml
       - bump-ansible-core-2.16-python-3.12.yml
     release_date: '2026-04-10'
+  4.12.0:
+    changes:
+      minor_changes:
+        - correlation_rule module - New module to create, update, and delete NG-SIEM
+          correlation rules (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).
+        - correlation_rule_info module - New module to query and retrieve NG-SIEM
+          correlation rule information (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).
+      release_summary: '| Release Date: 2026-05-17
+
+        | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.12.0>`__
+
+        '
+    fragments:
+      - 4.12.0.yaml
+      - 695-add-correlation-rule-modules.yml
+    modules:
+      - description: Manage NG\-SIEM correlation rules
+        name: correlation_rule
+        namespace: ''
+      - description: Get information about NG\-SIEM correlation rules
+        name: correlation_rule_info
+        namespace: ''
+    release_date: '2026-05-17'
   4.2.0:
     changes:
       minor_changes:

--- a/changelogs/fragments/4.12.0.yaml
+++ b/changelogs/fragments/4.12.0.yaml
@@ -1,3 +1,0 @@
-release_summary: |
-  | Release Date: 2026-05-17
-  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.12.0>`__

--- a/changelogs/fragments/4.12.0.yaml
+++ b/changelogs/fragments/4.12.0.yaml
@@ -1,0 +1,3 @@
+release_summary: |
+  | Release Date: 2026-05-17
+  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.12.0>`__

--- a/changelogs/fragments/695-add-correlation-rule-modules.yml
+++ b/changelogs/fragments/695-add-correlation-rule-modules.yml
@@ -1,6 +1,0 @@
----
-minor_changes:
-  - correlation_rule module - New module to create, update, and delete NG-SIEM correlation rules
-    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).
-  - correlation_rule_info module - New module to query and retrieve NG-SIEM correlation rule information
-    (https://github.com/CrowdStrike/ansible_collection_falcon/issues/695).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 4.11.2
+version: 4.12.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Minor version bump for the new `correlation_rule` and `correlation_rule_info` modules added in #696.

**Changes:**
- Add release summary fragment for 4.12.0
- Update `galaxy.yml` version to 4.12.0
- Generate changelog via `antsibull-changelog`