### PR TITLE
feat: add NG-SIEM data connection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ venv.bak/
 /**venv
 /**/.venv
 
+# Local credentials / dotenv files (live API creds for integration tests)
+.env
+.env.*
+!.env.example
+
 # Testing
 .tox
 .coverage

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Name | Description
 [crowdstrike.falcon.intel_rule_download](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_download_module.html)|Download CrowdStrike Falcon Intel rule files
 [crowdstrike.falcon.intel_rule_info](https://crowdstrike.github.io/ansible_collection_falcon/intel_rule_info_module.html)|Get information about CrowdStrike Falcon Intel rules
 [crowdstrike.falcon.kernel_support_info](https://crowdstrike.github.io/ansible_collection_falcon/kernel_support_info_module.html)|Get information about kernels supported by the Falcon Sensor for Linux
+[crowdstrike.falcon.ngsiem_data_connection](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connection_module.html)|Manage NG-SIEM data connections
+[crowdstrike.falcon.ngsiem_data_connection_info](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connection_info_module.html)|Get information about NG-SIEM data connections
+[crowdstrike.falcon.ngsiem_data_connector_info](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connector_info_module.html)|Get information about available NG-SIEM data connectors
 [crowdstrike.falcon.ngsiem_search](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_search_module.html)|Execute CQL searches against Next-Gen SIEM repositories for incident response and threat hunting
 [crowdstrike.falcon.sensor_download](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_module.html)|Download Falcon Sensor Installer
 [crowdstrike.falcon.sensor_download_info](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_info_module.html)|Get information about Falcon Sensor Installers

--- a/changelogs/fragments/704-add-ngsiem-data-connection-modules.yml
+++ b/changelogs/fragments/704-add-ngsiem-data-connection-modules.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - ngsiem_data_connection - new module to create, update, delete, and pause/resume NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+  - ngsiem_data_connection_info - new module to get information about NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+  - ngsiem_data_connector_info - new module to get information about available NG-SIEM data connectors (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)

--- a/plugins/modules/ngsiem_data_connection.py
+++ b/plugins/modules/ngsiem_data_connection.py
@@ -1,0 +1,710 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ngsiem_data_connection
+
+short_description: Manage NG-SIEM data connections
+
+version_added: "4.13.0"
+
+description:
+  - Create, update, delete, and pause/resume NG-SIEM data connections in the
+    CrowdStrike Falcon platform.
+  - Data connections feed third-party log sources into Next-Gen SIEM. They come
+    in two shapes - B(PULL) connections (e.g. AWS S3, Azure Event Hubs) where Falcon
+    pulls from your source using credentials in a C(config) block, and B(PUSH)
+    connections (e.g. HEC / HTTP Event Connector) where you push logs to an
+    C(ingest_url) using an ingest token.
+  - Supports idempotent operations that only make changes when necessary.
+  - Use M(crowdstrike.falcon.ngsiem_data_connector_info) to discover valid
+    I(connector_id) and I(parser) values.
+
+options:
+  state:
+    description:
+      - The desired state of the data connection.
+      - C(present) ensures the connection exists with the specified configuration.
+      - C(absent) ensures the connection does not exist.
+    type: str
+    choices: ["present", "absent"]
+    default: present
+  connection_id:
+    description:
+      - The ID of an existing data connection.
+      - Preferred for identifying existing connections during update, delete, or
+        pause/resume operations.
+      - Either I(connection_id) or I(name) is required.
+    type: str
+    required: false
+  name:
+    description:
+      - The name of the data connection.
+      - Required when creating a new connection and I(connection_id) is not provided.
+      - Used to look up an existing connection when I(connection_id) is not specified.
+    type: str
+    required: false
+  connector_id:
+    description:
+      - The ID of the connector this connection is based on.
+      - Required when creating a new connection.
+      - Use M(crowdstrike.falcon.ngsiem_data_connector_info) to discover available connectors.
+    type: str
+    required: false
+  parser:
+    description:
+      - The parser to apply to the connection's data.
+      - Required when creating a new connection.
+      - The value must be valid for the chosen connector (e.g. C(microsoft-edge)).
+        The API is the source of truth and will reject invalid parsers.
+    type: str
+    required: false
+  vendor_name:
+    description:
+      - The vendor name associated with the connection.
+    type: str
+    required: false
+  vendor_product_name:
+    description:
+      - The vendor product name associated with the connection.
+    type: str
+    required: false
+  description:
+    description:
+      - A description for the data connection.
+      - "B(Note:) This field is write-only. It is applied on create but is never
+        returned by the API, so changes to it alone cannot be detected for idempotency."
+    type: str
+    required: false
+  config:
+    description:
+      - A free-form configuration dict for the connection.
+      - Used by PULL connectors to supply authentication and parameters
+        (e.g. C(config.auth), C(config.params)).
+      - "B(Note:) This field is write-only. It is applied on create but is never
+        returned by the API, so changes to it alone cannot be detected for idempotency."
+    type: dict
+    required: false
+  config_id:
+    description:
+      - The ID of a saved connector config to associate with the connection.
+    type: str
+    required: false
+  connector_type:
+    description:
+      - The type of the connector.
+    type: str
+    required: false
+  log_sources:
+    description:
+      - A list of log sources for the connection.
+    type: list
+    elements: str
+    required: false
+  enable_host_enrichment:
+    description:
+      - Whether to enable host enrichment for the connection.
+      - "B(Note:) This field is write-only. It is applied on create but is never
+        returned by the API, so changes to it alone cannot be detected for idempotency."
+    type: bool
+    required: false
+  enable_user_enrichment:
+    description:
+      - Whether to enable user enrichment for the connection.
+      - "B(Note:) This field is write-only. It is applied on create but is never
+        returned by the API, so changes to it alone cannot be detected for idempotency."
+    type: bool
+    required: false
+  enabled:
+    description:
+      - Whether the connection should be running (resumed) or paused.
+      - C(true) resumes a paused connection; C(false) pauses a running connection.
+      - Only applied when the connection already exists.
+      - Pausing is only valid when the connection is in an C(Active), C(Error), or
+        C(Idle) state; the module reads the current status first and no-ops otherwise.
+    type: bool
+    required: false
+  wait_for_ingest_token:
+    description:
+      - Whether to wait for the ingest token to become available when creating a
+        PUSH connection.
+      - The token is minted on the first successful request, but immediately after
+        create the connection is still provisioning and the token endpoint returns
+        "not ready". When C(true), the module polls until the token is available or
+        I(wait_timeout) is reached.
+      - The token is a one-time secret - it can only be retrieved once, so enabling
+        this is the only reliable way to capture it during creation.
+      - Only applies to the create of a PUSH connection.
+    type: bool
+    required: false
+    default: true
+  wait_timeout:
+    description:
+      - Maximum number of seconds to wait for the ingest token when
+        I(wait_for_ingest_token) is C(true).
+      - If the token is still not available after this timeout, the connection is
+        left created and the module returns without the token (with a warning)
+        rather than failing.
+    type: int
+    required: false
+    default: 120
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+notes:
+  - B(Idempotency:) This module is idempotent and will only make changes when the
+    current state differs from the desired state.
+  - B(Drift detection:) Idempotency is determined by comparing I(name) and
+    I(parser) against the existing connection. Vendor fields are not compared
+    because some connectors (e.g. the built-in HEC connector) override
+    I(vendor_product_name) with their own value on create. Changes to
+    I(description), I(config), or the enrichment flags cannot be detected either
+    (the API never returns them); they are only applied on create.
+  - B(Connection Lookup:) When I(connection_id) is not provided, the module searches
+    by I(name). Prefer I(connection_id) for precise targeting.
+  - B(Ingest token:) For PUSH connections, an ingest token is minted and returned
+    once on create as the C(ingest_token) value alongside C(ingest_url). The token
+    cannot be retrieved again, so it is a sensitive value - handle and store it
+    securely. Because the connection is still provisioning immediately after create,
+    the module waits for the token by default (see I(wait_for_ingest_token) and
+    I(wait_timeout)). Token rotation is not supported in this module.
+  - B(State Management:) For I(state=absent), if the connection is not found, the
+    module exits successfully without making any changes (idempotent).
+
+requirements:
+  - NGSIEM Data Connections [B(READ), B(WRITE)] API scope
+  - CrowdStrike FalconPy >= 1.5.0
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Create a PUSH (HEC) data connection
+  crowdstrike.falcon.ngsiem_data_connection:
+    name: "Edge browser logs"
+    connector_id: "a1bfd0c4380f436790cb41afc2b95f38"
+    parser: "microsoft-edge"
+    vendor_name: "Microsoft"
+    vendor_product_name: "Edge"
+  register: hec_connection
+
+- name: Show the ingest URL (the token is sensitive and only returned once on create)
+  ansible.builtin.debug:
+    var: hec_connection.data_connection.ingest_url
+
+- name: Create a PULL (S3) data connection with auth config
+  crowdstrike.falcon.ngsiem_data_connection:
+    name: "AWS S3 CloudTrail"
+    connector_id: "0123456789abcdef0123456789abcdef"
+    parser: "aws-cloudtrail"
+    vendor_name: "AWS"
+    vendor_product_name: "CloudTrail"
+    config:
+      auth:
+        access_key_id: "{{ aws_access_key_id }}"
+        secret_access_key: "{{ aws_secret_access_key }}"
+      params:
+        bucket: "my-cloudtrail-bucket"
+        region: "us-east-1"
+
+- name: Update a connection's name by ID
+  crowdstrike.falcon.ngsiem_data_connection:
+    connection_id: "abcdef1234567890abcdef1234567890"
+    name: "Edge browser logs (renamed)"
+
+- name: Pause a connection
+  crowdstrike.falcon.ngsiem_data_connection:
+    connection_id: "abcdef1234567890abcdef1234567890"
+    enabled: false
+
+- name: Resume a connection
+  crowdstrike.falcon.ngsiem_data_connection:
+    connection_id: "abcdef1234567890abcdef1234567890"
+    enabled: true
+
+- name: Delete a connection by name
+  crowdstrike.falcon.ngsiem_data_connection:
+    name: "Edge browser logs"
+    state: absent
+
+- name: Delete a connection by ID
+  crowdstrike.falcon.ngsiem_data_connection:
+    connection_id: "abcdef1234567890abcdef1234567890"
+    state: absent
+"""
+
+RETURN = r"""
+data_connection:
+  description:
+    - Information about the data connection that was created or updated.
+    - Only fields returned by the API are included.
+  type: dict
+  returned: when state=present
+  contains:
+    id:
+      description: The unique identifier of the data connection.
+      type: str
+      returned: success
+      sample: "abcdef1234567890abcdef1234567890"
+    name:
+      description: The name of the data connection.
+      type: str
+      returned: success
+      sample: "Edge browser logs"
+    vendor_name:
+      description: The vendor name associated with the connection.
+      type: str
+      returned: success
+      sample: "Microsoft"
+    vendor_product_name:
+      description: The vendor product name associated with the connection.
+      type: str
+      returned: success
+      sample: "Edge"
+    parser_name:
+      description: The parser applied to the connection's data.
+      type: str
+      returned: success
+      sample: "microsoft-edge"
+    status:
+      description: The current status of the connection.
+      type: str
+      returned: success
+      sample: "Active"
+    source_type:
+      description: The source type of the connection.
+      type: str
+      returned: success
+    last_ingested_volume_one_day:
+      description: The volume ingested in the last day.
+      type: int
+      returned: success
+    ingest_url:
+      description: The URL to push logs to (PUSH connections only, after provisioning).
+      type: str
+      returned: when available
+      sample: "https://ingest.us-2.crowdstrike.com/services/collector/..."
+ingest_token:
+  description:
+    - The ingest token for a PUSH connection.
+    - Minted and returned B(only once), on create of a PUSH connection. It cannot
+      be retrieved again.
+    - This is a sensitive value; handle and store it securely.
+  type: str
+  returned: on create of a PUSH connection
+"""
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import NGSIEM, APIHarnessV2
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+# Operation ID for the raw ingest-token command (see fetch_ingest_token).
+INGEST_TOKEN_OPERATION = "ExternalGetDataConnectionToken"
+
+# Fields the API returns for an existing connection that we can compare against
+# module params for drift detection. description/config/enrichment flags are
+# write-only (never returned) so they cannot be compared here.
+READABLE_FIELDS = (
+    "id",
+    "name",
+    "vendor_name",
+    "vendor_product_name",
+    "parser_name",
+    "status",
+    "source_type",
+    "last_ingested_volume_one_day",
+    "ingest_url",
+)
+
+# Provisioning states from which a Pause is accepted by the API.
+PAUSABLE_STATUSES = ("Active", "Error", "Idle")
+
+NGSIEM_DATA_CONNECTION_ARGS = {
+    "state": {"type": "str", "choices": ["present", "absent"], "default": "present"},
+    "connection_id": {"type": "str", "required": False},
+    "name": {"type": "str", "required": False},
+    "connector_id": {"type": "str", "required": False},
+    "parser": {"type": "str", "required": False},
+    "vendor_name": {"type": "str", "required": False},
+    "vendor_product_name": {"type": "str", "required": False},
+    "description": {"type": "str", "required": False},
+    "config": {"type": "dict", "required": False},
+    "config_id": {"type": "str", "required": False},
+    "connector_type": {"type": "str", "required": False},
+    "log_sources": {"type": "list", "elements": "str", "required": False},
+    "enable_host_enrichment": {"type": "bool", "required": False},
+    "enable_user_enrichment": {"type": "bool", "required": False},
+    "enabled": {"type": "bool", "required": False},
+    "wait_for_ingest_token": {"type": "bool", "required": False, "default": True},
+    "wait_timeout": {"type": "int", "required": False, "default": 120},
+}
+
+# Body fields passed through on create/update, mapped from module param names to
+# the API body key.
+BODY_FIELDS = {
+    "name": "name",
+    "connector_id": "connector_id",
+    "parser": "parser",
+    "vendor_name": "vendor_name",
+    "vendor_product_name": "vendor_product_name",
+    "description": "description",
+    "config": "config",
+    "config_id": "config_id",
+    "connector_type": "connector_type",
+    "log_sources": "log_sources",
+    "enable_host_enrichment": "enable_host_enrichment",
+    "enable_user_enrichment": "enable_user_enrichment",
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(NGSIEM_DATA_CONNECTION_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    connection_id = module.params.get("connection_id")
+    name = module.params.get("name")
+
+    if not connection_id and not name:
+        module.fail_json(
+            msg="Either 'connection_id' or 'name' is required"
+        )
+
+
+def build_body(module):
+    """Build the create/update request body from module params."""
+    body = {}
+    for param, key in BODY_FIELDS.items():
+        value = module.params.get(param)
+        if value is not None:
+            body[key] = value
+    return body
+
+
+def get_existing(falcon, connection_id):
+    """Get an existing data connection by ID."""
+    result = falcon.get_connection_by_id(ids=[connection_id])
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0]
+    return None
+
+
+def find_connection_by_name(falcon, name):
+    """Find a data connection by name."""
+    result = falcon.list_data_connections(filter=f"name:'{name}'", limit=1)
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0]
+    return None
+
+
+def connection_needs_update(current, module):
+    """Check if the connection needs updating based on readable fields only.
+
+    Only ``name`` and ``parser`` are compared. Vendor fields are excluded on
+    purpose: some connectors (e.g. the built-in HEC connector) override
+    ``vendor_product_name`` (and potentially ``vendor_name``) with their own
+    value on create, so comparing them would report drift on every run and
+    trigger an endless update loop. ``description``/``config``/enrichment flags
+    are write-only and never returned, so they cannot be compared either.
+    """
+    comparisons = (
+        ("name", "name"),
+        ("parser", "parser_name"),
+    )
+    for param, current_key in comparisons:
+        value = module.params.get(param)
+        if value is not None and current.get(current_key) != value:
+            return True
+    return False
+
+
+def get_current_status(falcon, connection_id):
+    """Return the current provisioning status of a connection, or None."""
+    result = falcon.get_provisioning_status(ids=connection_id)
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0].get("status")
+    return None
+
+
+def apply_enabled(falcon, module, result, connection_id):
+    """Pause or resume a connection to match the desired 'enabled' state."""
+    enabled = module.params.get("enabled")
+    if enabled is None:
+        return
+
+    current_status = get_current_status(falcon, connection_id)
+
+    if enabled is False:
+        # Only pause from a pausable state, and only if not already paused.
+        if current_status in PAUSABLE_STATUSES:
+            status_result = falcon.update_connection_status(
+                ids=connection_id, status="Pause"
+            )
+            if status_result["status_code"] != 200:
+                handle_return_errors(module, result, status_result)
+            result["changed"] = True
+    else:
+        # Resume only if currently paused.
+        if current_status == "Paused":
+            status_result = falcon.update_connection_status(
+                ids=connection_id, status="Resume"
+            )
+            if status_result["status_code"] != 200:
+                handle_return_errors(module, result, status_result)
+            result["changed"] = True
+
+
+def _extract_token(token_result, result):
+    """Pull token/url out of a token command response. Returns True if a token was found.
+
+    The ingest-token endpoint returns ``resources`` as a *dict* (not a list):
+      - 200: ``{"token": ..., "ingest_url": ..., "created_at": ..., "expires_at": ...}``
+      - 202: ``{"error": "ConnectionNotReady", "message": ...}`` (still provisioning)
+    """
+    if token_result.get("status_code") != 200:
+        return False
+    token_data = (token_result.get("body") or {}).get("resources")
+    if not isinstance(token_data, dict):
+        return False
+    token = token_data.get("token")
+    if token:
+        result["ingest_token"] = token
+    ingest_url = token_data.get("ingest_url") or token_data.get("url")
+    if ingest_url and not result["data_connection"].get("ingest_url"):
+        result["data_connection"]["ingest_url"] = ingest_url
+    return bool(token)
+
+
+def _attempt_token(uber, result, connection_id):
+    """Make a single token request via the raw command interface.
+
+    Returns one of:
+      - "found"    : the token was captured into result
+      - "retry"    : not ready yet (202); poll again
+      - "terminal" : a definitive non-200/202 (e.g. a PULL connection with no token)
+
+    IMPORTANT: this uses the uber-class ``command`` rather than the typed
+    ``NGSIEM.get_ingest_token``. In FalconPy 1.6.1 the typed method assumes
+    ``resources`` is a list and does ``resources[0]``, but this endpoint returns a
+    dict - so the typed call raises ``KeyError(0)`` on every request, including the
+    one that mints the token. Because the token is minted exactly once (subsequent
+    calls return 400 "already generated"), that crash permanently loses the secret.
+    The raw command returns the unparsed body, so we read the dict directly.
+    """
+    token_result = uber.command(INGEST_TOKEN_OPERATION, ids=connection_id)
+    if _extract_token(token_result, result):
+        return "found"
+    if token_result.get("status_code") == 202:
+        return "retry"
+    return "terminal"
+
+
+def fetch_ingest_token(module, result, connection_id):
+    """Mint/fetch the ingest token for a freshly created connection.
+
+    Only meaningful for PUSH connections. The token is minted on the first
+    successful (200) request; immediately after create the connection is still
+    provisioning and the endpoint returns 202 ("ConnectionNotReady"). When
+    I(wait_for_ingest_token) is set the module polls until the token is available
+    or I(wait_timeout) is reached. For non-PUSH connections the endpoint returns a
+    terminal non-200 and we simply skip it.
+
+    Token retrieval happens *after* the connection is already created, so nothing
+    here fails the task (that would orphan the connection) - a missing token is a
+    warning, never an error. The uber-class is authenticated with the same
+    credentials as the main service.
+    """
+    try:
+        uber = authenticate(module, APIHarnessV2)
+
+        outcome = _attempt_token(uber, result, connection_id)
+        if outcome in ("found", "terminal"):
+            return
+
+        # Not ready yet.
+        if not module.params.get("wait_for_ingest_token"):
+            module.warn(
+                "Ingest token is not ready yet (connection still provisioning). "
+                "Set wait_for_ingest_token=true to poll for it. The token can only "
+                "be retrieved once and is not available on later runs."
+            )
+            return
+
+        timeout = module.params.get("wait_timeout")
+        interval = 5
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            time.sleep(interval)
+            outcome = _attempt_token(uber, result, connection_id)
+            if outcome in ("found", "terminal"):
+                return
+
+        module.warn(
+            f"Timed out after {timeout}s waiting for the ingest token to become "
+            "available. The connection was created, but the token could not be "
+            "retrieved. It can only be retrieved once and is not available on later runs."
+        )
+    except Exception as e:  # pragma: no cover - never fail the task over the token
+        module.warn(
+            f"The connection was created but retrieving the ingest token failed: {e}. "
+            "The token can only be retrieved once and is not available on later runs."
+        )
+
+
+def filter_readable(connection):
+    """Return only the API-returned fields for a connection."""
+    return {k: connection[k] for k in READABLE_FIELDS if k in connection}
+
+
+def handle_present(falcon, module, result):
+    """Handle state=present (create or update)."""
+    connection_id = module.params.get("connection_id")
+    name = module.params.get("name")
+
+    current = None
+    if connection_id:
+        current = get_existing(falcon, connection_id)
+        if not current:
+            module.fail_json(
+                msg=f"Data connection with ID '{connection_id}' not found"
+            )
+    elif name:
+        current = find_connection_by_name(falcon, name)
+
+    if current:
+        cid = current["id"]
+        if connection_needs_update(current, module):
+            body = build_body(module)
+            # NOTE: the API reads the connection ID from the 'parameters' dict.
+            # Passing ids= is silently ignored and returns a 400. See the
+            # feasibility investigation for details.
+            update_result = falcon.update_data_connection(
+                parameters={"ids": cid}, body=body
+            )
+            if update_result["status_code"] not in (200, 201):
+                handle_return_errors(module, result, update_result)
+            result["changed"] = True
+            updated = get_existing(falcon, cid)
+            result["data_connection"] = filter_readable(updated or current)
+        else:
+            result["data_connection"] = filter_readable(current)
+
+        apply_enabled(falcon, module, result, cid)
+    else:
+        # Creating a new connection requires connector_id and parser.
+        for required in ("connector_id", "parser"):
+            if not module.params.get(required):
+                module.fail_json(
+                    msg=f"Parameter '{required}' is required when creating a data connection"
+                )
+
+        body = build_body(module)
+        create_result = falcon.create_data_connection(body=body)
+        if create_result["status_code"] not in (200, 201):
+            handle_return_errors(module, result, create_result)
+
+        resources = create_result["body"].get("resources") or []
+        if resources:
+            new_id = resources[0]["id"]
+            result["changed"] = True
+
+            created = get_existing(falcon, new_id)
+            result["data_connection"] = filter_readable(created) if created else {"id": new_id}
+
+            # PUSH connections mint an ingest token on first ready fetch. For
+            # non-PUSH connections this is a no-op.
+            fetch_ingest_token(module, result, new_id)
+
+
+def handle_absent(falcon, module, result):
+    """Handle state=absent (delete)."""
+    connection_id = module.params.get("connection_id")
+    name = module.params.get("name")
+
+    current = None
+    if connection_id:
+        current = get_existing(falcon, connection_id)
+    elif name:
+        current = find_connection_by_name(falcon, name)
+
+    if current:
+        delete_result = falcon.delete_data_connection(ids=current["id"])
+        if delete_result["status_code"] not in (200, 201):
+            handle_return_errors(module, result, delete_result)
+        result["changed"] = True
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+    validate_params(module)
+
+    result = dict(
+        changed=False,
+    )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    falcon = authenticate(module, NGSIEM)
+
+    try:
+        if module.params["state"] == "present":
+            handle_present(falcon, module, result)
+        else:
+            handle_absent(falcon, module, result)
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while managing the data connection: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ngsiem_data_connection_info.py
+++ b/plugins/modules/ngsiem_data_connection_info.py
@@ -1,0 +1,358 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ngsiem_data_connection_info
+
+short_description: Get information about NG-SIEM data connections
+
+version_added: "4.13.0"
+
+description:
+  - Returns detailed information for one or more NG-SIEM data connections.
+  - Some of the details returned include connection name, vendor, parser, status,
+    source type, and ingest URL.
+  - Can retrieve specific connections by ID or search for connections using FQL filters.
+  - Optionally enriches each result with its current provisioning status.
+
+options:
+  connection_ids:
+    description:
+      - A list of data connection IDs to get information about.
+      - If not provided, connections will be returned based on filter and pagination settings.
+      - Cannot be used together with I(filter).
+    type: list
+    elements: str
+    required: false
+  filter:
+    description:
+      - FQL (Falcon Query Language) filter expression to limit results.
+      - "Supported fields: C(name), C(id), C(vendor_name), C(vendor_product_name),
+        C(status), C(type)."
+      - "C(status) accepts: C(Pending), C(Active), C(Disconnected), C(Error), C(Idle), C(Paused)."
+      - "C(type) accepts: C(PUSH), C(PULL)."
+      - "Examples: C(name:'*edge*'), C(status:'Active'), C(type:'PUSH')."
+      - Cannot be used together with I(connection_ids).
+    type: str
+    required: false
+  limit:
+    description:
+      - Maximum number of data connections to return.
+      - Must be between 1 and 500.
+    type: int
+    default: 100
+  offset:
+    description:
+      - Starting index for pagination.
+      - Use with I(limit) to paginate through large result sets.
+    type: int
+    default: 0
+  sort:
+    description:
+      - Property to sort results by.
+      - "B(Note:) Only C(name.asc) is supported by the API. Other sort values are rejected."
+    type: str
+    required: false
+  include_status:
+    description:
+      - Whether to enrich each connection with its current provisioning status.
+      - When enabled, adds a C(provisioning_status) field to each connection.
+      - This requires an additional API call per connection.
+    type: bool
+    default: false
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+requirements:
+  - NGSIEM Data Connections [B(READ)] API scope
+  - CrowdStrike FalconPy >= 1.5.0
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Get all data connections
+  crowdstrike.falcon.ngsiem_data_connection_info:
+
+- name: Get specific data connections by ID
+  crowdstrike.falcon.ngsiem_data_connection_info:
+    connection_ids:
+      - "abcdef1234567890abcdef1234567890"
+      - "1234567890abcdef1234567890abcdef"
+
+- name: Search connections by name pattern
+  crowdstrike.falcon.ngsiem_data_connection_info:
+    filter: "name:'*edge*'"
+    limit: 50
+
+- name: Filter connections by status
+  crowdstrike.falcon.ngsiem_data_connection_info:
+    filter: "status:'Active'"
+    sort: "name.asc"
+
+- name: Filter PUSH connections and include provisioning status
+  crowdstrike.falcon.ngsiem_data_connection_info:
+    filter: "type:'PUSH'"
+    include_status: true
+"""
+
+RETURN = r"""
+data_connections:
+  description:
+    - A list of data connections that match the search criteria.
+  type: list
+  returned: success
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the data connection.
+      type: str
+      returned: success
+      sample: "abcdef1234567890abcdef1234567890"
+    name:
+      description: The name of the data connection.
+      type: str
+      returned: success
+      sample: "Edge browser logs"
+    vendor_name:
+      description: The vendor name associated with the connection.
+      type: str
+      returned: success
+      sample: "Microsoft"
+    vendor_product_name:
+      description: The vendor product name associated with the connection.
+      type: str
+      returned: success
+      sample: "Edge"
+    parser_name:
+      description: The parser applied to the connection's data.
+      type: str
+      returned: success
+      sample: "microsoft-edge"
+    status:
+      description: The current status of the connection.
+      type: str
+      returned: success
+      sample: "Active"
+    source_type:
+      description: The source type of the connection.
+      type: str
+      returned: success
+    last_ingested_volume_one_day:
+      description: The volume ingested in the last day.
+      type: int
+      returned: success
+    ingest_url:
+      description: The URL to push logs to (PUSH connections only, after provisioning).
+      type: str
+      returned: when available
+    provisioning_status:
+      description: The current provisioning status (only when include_status=true).
+      type: dict
+      returned: when include_status=true
+meta:
+  description: Metadata about the query results.
+  type: dict
+  returned: success
+  contains:
+    query_time:
+      description: Time taken to execute the query in seconds.
+      type: float
+      returned: success
+      sample: 0.123
+    pagination:
+      description: Pagination information.
+      type: dict
+      returned: success
+      contains:
+        offset:
+          description: The starting index used for this query.
+          type: int
+          returned: success
+          sample: 0
+        limit:
+          description: The limit used for this query.
+          type: int
+          returned: success
+          sample: 100
+        total:
+          description: Total number of data connections matching the query.
+          type: int
+          returned: success
+          sample: 42
+"""
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import NGSIEM
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+NGSIEM_DATA_CONNECTION_INFO_ARGS = {
+    "connection_ids": {"type": "list", "elements": "str", "required": False},
+    "filter": {"type": "str", "required": False},
+    "limit": {"type": "int", "default": 100},
+    "offset": {"type": "int", "default": 0},
+    "sort": {"type": "str", "required": False},
+    "include_status": {"type": "bool", "default": False},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(NGSIEM_DATA_CONNECTION_INFO_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    if module.params.get("connection_ids") and module.params.get("filter"):
+        module.fail_json(
+            msg="Parameters 'connection_ids' and 'filter' are mutually exclusive"
+        )
+
+    limit = module.params["limit"]
+    if limit < 1 or limit > 500:
+        module.fail_json(msg="Parameter 'limit' must be between 1 and 500")
+
+    offset = module.params["offset"]
+    if offset < 0:
+        module.fail_json(msg="Parameter 'offset' must be 0 or greater")
+
+
+def get_connections_by_ids(falcon, connection_ids):
+    """Retrieve data connections by their IDs."""
+    return falcon.get_connection_by_id(ids=connection_ids)
+
+
+def search_connections(falcon, module):
+    """Search for data connections using filters and pagination."""
+    params = {
+        "limit": module.params["limit"],
+        "offset": module.params["offset"],
+    }
+
+    if module.params.get("filter"):
+        params["filter"] = module.params["filter"]
+
+    if module.params.get("sort"):
+        params["sort"] = module.params["sort"]
+
+    return falcon.list_data_connections(**params)
+
+
+def enrich_status(falcon, connections):
+    """Add provisioning status to each connection."""
+    for connection in connections:
+        status_result = falcon.get_provisioning_status(ids=connection["id"])
+        if status_result["status_code"] == 200 and status_result["body"].get("resources"):
+            connection["provisioning_status"] = status_result["body"]["resources"][0]
+        else:
+            connection["provisioning_status"] = {}
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+    validate_params(module)
+
+    start_time = time.time()
+    data_connections = []
+    falcon = authenticate(module, NGSIEM)
+
+    result = dict(
+        changed=False,
+        data_connections=[],
+        meta={},
+    )
+
+    try:
+        if module.params.get("connection_ids"):
+            query_result = get_connections_by_ids(falcon, module.params["connection_ids"])
+
+            if query_result["status_code"] == 200:
+                data_connections = query_result["body"]["resources"]
+
+                result["meta"] = {
+                    "query_time": time.time() - start_time,
+                    "pagination": {
+                        "offset": 0,
+                        "limit": len(data_connections),
+                        "total": len(data_connections),
+                    },
+                }
+        else:
+            query_result = search_connections(falcon, module)
+
+            if query_result["status_code"] == 200:
+                data_connections = query_result["body"]["resources"]
+
+                meta = query_result["body"].get("meta", {})
+                result["meta"] = {
+                    "query_time": time.time() - start_time,
+                    "pagination": {
+                        "offset": module.params["offset"],
+                        "limit": module.params["limit"],
+                        "total": meta.get("pagination", {}).get(
+                            "total", len(data_connections)
+                        ),
+                    },
+                }
+
+        if module.params["include_status"] and data_connections:
+            enrich_status(falcon, data_connections)
+
+        result["data_connections"] = data_connections
+
+        handle_return_errors(module, result, query_result)
+
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while retrieving data connection information: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ngsiem_data_connector_info.py
+++ b/plugins/modules/ngsiem_data_connector_info.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ngsiem_data_connector_info
+
+short_description: Get information about available NG-SIEM data connectors
+
+version_added: "4.13.0"
+
+description:
+  - Returns the catalog of available NG-SIEM data connectors.
+  - Connectors are the templates that data connections are built from. Use this
+    module to discover valid I(connector_id) and I(parser) values for
+    M(crowdstrike.falcon.ngsiem_data_connection).
+  - Some of the details returned include connector name, description, supported
+    parsers, vendor, type, and subscription.
+
+options:
+  filter:
+    description:
+      - FQL (Falcon Query Language) filter expression to limit results.
+      - "Supported fields: C(name), C(vendor_name), C(type), C(subscription)."
+      - "C(type) accepts: C(PUSH), C(PULL)."
+      - "Examples: C(name:'*S3*'), C(vendor_name:'AWS'), C(type:'PULL')."
+    type: str
+    required: false
+  limit:
+    description:
+      - Maximum number of data connectors to return.
+      - Must be between 1 and 500.
+    type: int
+    default: 100
+  offset:
+    description:
+      - Starting index for pagination.
+      - Use with I(limit) to paginate through large result sets.
+    type: int
+    default: 0
+  sort:
+    description:
+      - Property to sort results by.
+    type: str
+    required: false
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+requirements:
+  - NGSIEM Data Connections [B(READ)] API scope
+  - CrowdStrike FalconPy >= 1.5.0
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Get all available data connectors
+  crowdstrike.falcon.ngsiem_data_connector_info:
+
+- name: Search connectors by name pattern
+  crowdstrike.falcon.ngsiem_data_connector_info:
+    filter: "name:'*S3*'"
+    limit: 50
+
+- name: Filter connectors by vendor
+  crowdstrike.falcon.ngsiem_data_connector_info:
+    filter: "vendor_name:'AWS'"
+
+- name: Filter PULL connectors
+  crowdstrike.falcon.ngsiem_data_connector_info:
+    filter: "type:'PULL'"
+"""
+
+RETURN = r"""
+data_connectors:
+  description:
+    - A list of available data connectors that match the search criteria.
+  type: list
+  returned: success
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the connector.
+      type: str
+      returned: success
+      sample: "a1bfd0c4380f436790cb41afc2b95f38"
+    name:
+      description: The name of the connector.
+      type: str
+      returned: success
+      sample: "HTTP Event Connector"
+    description:
+      description: The description of the connector.
+      type: str
+      returned: success
+    parsers:
+      description: The parsers supported by the connector.
+      type: list
+      returned: success
+      elements: str
+    vendor_name:
+      description: The vendor name associated with the connector.
+      type: str
+      returned: success
+      sample: "Generic"
+    vendor_product_name:
+      description: The vendor product name associated with the connector.
+      type: str
+      returned: success
+    type:
+      description: The connector type (PUSH or PULL).
+      type: str
+      returned: success
+      sample: "PUSH"
+    subscription:
+      description: The subscription associated with the connector.
+      type: str
+      returned: success
+meta:
+  description: Metadata about the query results.
+  type: dict
+  returned: success
+  contains:
+    query_time:
+      description: Time taken to execute the query in seconds.
+      type: float
+      returned: success
+      sample: 0.123
+    pagination:
+      description: Pagination information.
+      type: dict
+      returned: success
+      contains:
+        offset:
+          description: The starting index used for this query.
+          type: int
+          returned: success
+          sample: 0
+        limit:
+          description: The limit used for this query.
+          type: int
+          returned: success
+          sample: 100
+        total:
+          description: Total number of data connectors matching the query.
+          type: int
+          returned: success
+          sample: 157
+"""
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import NGSIEM
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+NGSIEM_DATA_CONNECTOR_INFO_ARGS = {
+    "filter": {"type": "str", "required": False},
+    "limit": {"type": "int", "default": 100},
+    "offset": {"type": "int", "default": 0},
+    "sort": {"type": "str", "required": False},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(NGSIEM_DATA_CONNECTOR_INFO_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    limit = module.params["limit"]
+    if limit < 1 or limit > 500:
+        module.fail_json(msg="Parameter 'limit' must be between 1 and 500")
+
+    offset = module.params["offset"]
+    if offset < 0:
+        module.fail_json(msg="Parameter 'offset' must be 0 or greater")
+
+
+def search_connectors(falcon, module):
+    """Search for data connectors using filters and pagination."""
+    params = {
+        "limit": module.params["limit"],
+        "offset": module.params["offset"],
+    }
+
+    if module.params.get("filter"):
+        params["filter"] = module.params["filter"]
+
+    if module.params.get("sort"):
+        params["sort"] = module.params["sort"]
+
+    return falcon.list_data_connectors(**params)
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module)
+    validate_params(module)
+
+    start_time = time.time()
+    data_connectors = []
+    falcon = authenticate(module, NGSIEM)
+
+    result = dict(
+        changed=False,
+        data_connectors=[],
+        meta={},
+    )
+
+    try:
+        query_result = search_connectors(falcon, module)
+
+        if query_result["status_code"] == 200:
+            data_connectors = query_result["body"]["resources"]
+
+            meta = query_result["body"].get("meta", {})
+            result["meta"] = {
+                "query_time": time.time() - start_time,
+                "pagination": {
+                    "offset": module.params["offset"],
+                    "limit": module.params["limit"],
+                    "total": meta.get("pagination", {}).get(
+                        "total", len(data_connectors)
+                    ),
+                },
+            }
+
+        result["data_connectors"] = data_connectors
+
+        handle_return_errors(module, result, query_result)
+
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while retrieving data connector information: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Run collection integration test targets against a live Falcon tenant.
+
+Ansible requires content to live in an ``ansible_collections/<ns>/<name>/``
+directory layout, and ``ansible-test`` scrubs the environment so credentials
+passed as env vars never reach the module. This wrapper works around both:
+
+  * it stages a symlinked ``ansible_collections/crowdstrike/falcon`` layout in a
+    temp dir (no copying - the symlink points at this checkout), and
+  * it runs each target's ``tasks/main.yml`` through plain ``ansible-playbook``
+    so the process environment (and therefore ``lookup('env', ...)``) is intact.
+
+Credentials are read from a ``.env`` file (via python-dotenv, if present) or from
+the existing process environment. Required: ``FALCON_CLIENT_ID`` and
+``FALCON_CLIENT_SECRET``; optional: ``FALCON_CLOUD``.
+
+Usage:
+    uv run tests/integration/run.py                       # run all targets
+    uv run tests/integration/run.py ngsiem_data_connection # run specific target(s)
+    uv run tests/integration/run.py --list                # list available targets
+    uv run tests/integration/run.py -- -vvv               # pass extra args to ansible-playbook
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# This file lives at <collection>/tests/integration/run.py
+INTEGRATION_DIR = Path(__file__).resolve().parent
+COLLECTION_ROOT = INTEGRATION_DIR.parent.parent
+TARGETS_DIR = INTEGRATION_DIR / "targets"
+
+NAMESPACE = "crowdstrike"
+COLLECTION = "falcon"
+
+REQUIRED_ENV = ("FALCON_CLIENT_ID", "FALCON_CLIENT_SECRET")
+
+
+def discover_targets():
+    """Return the sorted names of integration targets that have a tasks/main.yml."""
+    if not TARGETS_DIR.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in TARGETS_DIR.iterdir()
+        if p.is_dir() and (p / "tasks" / "main.yml").is_file()
+    )
+
+
+def load_dotenv_if_present():
+    """Load a .env file from the collection root into the environment, if available.
+
+    Existing environment variables always win over .env values, so creds already
+    exported in the shell take precedence. python-dotenv is optional; if it is not
+    installed we simply rely on the current environment.
+    """
+    env_file = COLLECTION_ROOT / ".env"
+    if not env_file.is_file():
+        return
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        sys.stderr.write(
+            "note: found .env but python-dotenv is not installed; "
+            "relying on existing environment variables.\n"
+        )
+        return
+    load_dotenv(dotenv_path=env_file, override=False)
+
+
+def detect_interpreter():
+    """Return a Python interpreter that can import falconpy.
+
+    Prefers the interpreter running this script (typically 'uv run' with falconpy
+    available). Falls back to the collection's local .venv.
+    """
+    candidates = [sys.executable, str(COLLECTION_ROOT / ".venv" / "bin" / "python3")]
+    for candidate in candidates:
+        if not candidate or not Path(candidate).exists():
+            continue
+        probe = subprocess.run(
+            [candidate, "-c", "import falconpy"],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode == 0:
+            return candidate
+    return None
+
+
+def build_playbook(staging_dir, targets):
+    """Write a wrapper playbook that includes each target's tasks and return its path."""
+    rel = f"ansible_collections/{NAMESPACE}/{COLLECTION}/tests/integration/targets"
+    tasks = "\n".join(
+        f"    - name: Run target '{t}'\n"
+        f"      ansible.builtin.include_tasks: "
+        f'"{{{{ playbook_dir }}}}/{rel}/{t}/tasks/main.yml"'
+        for t in targets
+    )
+    content = (
+        "---\n"
+        "- name: CrowdStrike Falcon integration tests\n"
+        "  hosts: localhost\n"
+        "  gather_facts: false\n"
+        "  tasks:\n"
+        f"{tasks}\n"
+    )
+    playbook = staging_dir / "run_integration.yml"
+    playbook.write_text(content)
+    return playbook
+
+
+def main():
+    """Parse arguments, stage the layout, and run the requested targets."""
+    # Split on '--': everything after it is passed through to ansible-playbook.
+    argv = sys.argv[1:]
+    passthrough = []
+    if "--" in argv:
+        idx = argv.index("--")
+        argv, passthrough = argv[:idx], argv[idx + 1:]
+
+    parser = argparse.ArgumentParser(
+        description="Run collection integration targets against a live tenant.",
+        epilog="Args after '--' are passed through to ansible-playbook.",
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        help="Target name(s) to run. Defaults to all discovered targets.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available integration targets and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    available = discover_targets()
+
+    if args.list:
+        if available:
+            print("Available integration targets:")
+            for name in available:
+                print(f"  {name}")
+        else:
+            print("No integration targets found.")
+        return 0
+
+    targets = args.targets or available
+    if not targets:
+        sys.stderr.write("error: no integration targets found to run.\n")
+        return 1
+
+    unknown = [t for t in targets if t not in available]
+    if unknown:
+        sys.stderr.write(
+            f"error: unknown target(s): {', '.join(unknown)}\n"
+            f"available: {', '.join(available) or '(none)'}\n"
+        )
+        return 1
+
+    load_dotenv_if_present()
+
+    missing = [var for var in REQUIRED_ENV if not os.environ.get(var)]
+    if missing:
+        sys.stderr.write(
+            f"error: missing required environment variable(s): {', '.join(missing)}\n"
+            "Set them in the environment or in a .env file at the collection root.\n"
+        )
+        return 1
+
+    interpreter = detect_interpreter()
+    if not interpreter:
+        sys.stderr.write(
+            "error: could not find a Python interpreter with falconpy installed.\n"
+            "Run this via 'uv run tests/integration/run.py' or install falconpy.\n"
+        )
+        return 1
+
+    if not shutil.which("ansible-playbook"):
+        sys.stderr.write("error: ansible-playbook not found on PATH.\n")
+        return 1
+
+    staging_dir = Path(tempfile.mkdtemp(prefix="cs-falcon-itest-"))
+    try:
+        link_parent = staging_dir / "ansible_collections" / NAMESPACE
+        link_parent.mkdir(parents=True)
+        (link_parent / COLLECTION).symlink_to(COLLECTION_ROOT)
+
+        playbook = build_playbook(staging_dir, targets)
+
+        env = os.environ.copy()
+        env["ANSIBLE_COLLECTIONS_PATH"] = str(staging_dir)
+
+        cmd = [
+            "ansible-playbook",
+            str(playbook),
+            "-e",
+            f"ansible_python_interpreter={interpreter}",
+            *passthrough,
+        ]
+
+        print(f"Running targets: {', '.join(targets)}")
+        print(f"Interpreter: {interpreter}\n")
+        completed = subprocess.run(cmd, env=env, check=False)
+        return completed.returncode
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/targets/ngsiem_data_connection/aliases
+++ b/tests/integration/targets/ngsiem_data_connection/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ngsiem_data_connection/tasks/main.yml
+++ b/tests/integration/targets/ngsiem_data_connection/tasks/main.yml
@@ -1,0 +1,309 @@
+---
+# Integration tests for the ngsiem_data_connection, ngsiem_data_connection_info,
+# and ngsiem_data_connector_info modules.
+#
+# Requirements:
+#   FALCON_CLIENT_ID     - API client ID
+#   FALCON_CLIENT_SECRET - API client secret
+#   FALCON_CLOUD         - Falcon cloud region (optional, defaults to us-1)
+#
+# API scopes: NGSIEM Data Connections [READ, WRITE]
+#
+# Notes on tenant behavior these tests account for:
+#   - A newly created connection enters a "Pending"/"Created" provisioning state.
+#     Pause/Resume is only valid from Active/Error/Idle, so this suite does NOT
+#     exercise pause/resume (it would be timing-dependent). It is validated
+#     separately once a connection reaches a steady state.
+#   - For a PUSH connection the ingest token is minted once on create, but during
+#     provisioning the token endpoint may return 202 (not ready). These tests
+#     therefore assert the token/url only when present.
+#   - The API only returns name, parser_name, vendor_name, vendor_product_name,
+#     status, source_type, last_ingested_volume_one_day, and ingest_url for a
+#     connection. description/config/enrichment flags are write-only.
+
+- name: Gather minimal facts for timestamp
+  ansible.builtin.setup:
+    gather_subset:
+      - date_time
+
+- name: Validate required environment variables
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'FALCON_CLIENT_ID') | length > 0
+      - lookup('env', 'FALCON_CLIENT_SECRET') | length > 0
+    fail_msg: "FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables must be set"
+
+- name: Set test variables
+  ansible.builtin.set_fact:
+    # Built-in HEC / HTTP Event Connector (PUSH) and a valid parser for it.
+    test_connector_id: "a1bfd0c4380f436790cb41afc2b95f38"
+    test_parser: "microsoft-edge"
+    test_connection_name: "ansible-test-DELETEME-{{ ansible_facts.date_time.iso8601_basic_short }}"
+
+- name: Run data connection lifecycle tests
+  block:
+    # =====================================================================
+    # Phase 0: CONNECTOR CATALOG (discovery)
+    # =====================================================================
+
+    - name: "CONNECTORS | List available connectors"
+      crowdstrike.falcon.ngsiem_data_connector_info:
+        limit: 100
+      register: connectors_all
+
+    - name: "CONNECTORS | Verify catalog returned"
+      ansible.builtin.assert:
+        that:
+          - connectors_all.data_connectors is defined
+          - connectors_all.data_connectors | length > 0
+          - connectors_all.meta.pagination.limit == 100
+        fail_msg: "Connector catalog was empty or malformed"
+
+    - name: "CONNECTORS | Filter connectors by type PUSH"
+      crowdstrike.falcon.ngsiem_data_connector_info:
+        filter: "type:'PUSH'"
+        limit: 50
+      register: connectors_push
+
+    - name: "CONNECTORS | Verify PUSH filter returned results"
+      ansible.builtin.assert:
+        that:
+          - connectors_push.data_connectors is defined
+        fail_msg: "PUSH connector filter query failed"
+
+    # =====================================================================
+    # Phase 1: CREATE
+    # =====================================================================
+
+    - name: "CREATE | Create a PUSH (HEC) data connection"
+      crowdstrike.falcon.ngsiem_data_connection:
+        name: "{{ test_connection_name }}"
+        connector_id: "{{ test_connector_id }}"
+        parser: "{{ test_parser }}"
+        vendor_name: "Ansible"
+        vendor_product_name: "IntegrationTest"
+        description: "Created by ansible integration tests - safe to delete"
+        wait_for_ingest_token: true
+        wait_timeout: 180
+      register: create_result
+
+    - name: "CREATE | Verify connection was created"
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - create_result.data_connection is defined
+          - create_result.data_connection.id | length > 0
+          - create_result.data_connection.name == test_connection_name
+          - create_result.data_connection.parser_name == test_parser
+          - create_result.data_connection.vendor_name == "Ansible"
+        fail_msg: "Connection creation failed or returned unexpected data"
+
+    - name: Save connection ID
+      ansible.builtin.set_fact:
+        connection_id: "{{ create_result.data_connection.id }}"
+
+    - name: "CREATE | Verify ingest token and URL were captured (PUSH + wait_for_ingest_token)"
+      ansible.builtin.assert:
+        that:
+          - create_result.ingest_token is defined
+          - create_result.ingest_token | length > 0
+          - create_result.data_connection.ingest_url is defined
+          - create_result.data_connection.ingest_url | length > 0
+        fail_msg: >-
+          Expected the ingest token and URL to be captured on create when
+          wait_for_ingest_token is true. If this times out, increase wait_timeout.
+
+    # =====================================================================
+    # Phase 1b: CREATE IDEMPOTENCY - re-declaring the same connection is a no-op
+    # =====================================================================
+
+    - name: "IDEMPOTENT | Re-declare the same connection by name"
+      crowdstrike.falcon.ngsiem_data_connection:
+        name: "{{ test_connection_name }}"
+        connector_id: "{{ test_connector_id }}"
+        parser: "{{ test_parser }}"
+        vendor_name: "Ansible"
+        vendor_product_name: "IntegrationTest"
+        description: "Created by ansible integration tests - safe to delete"
+      register: create_idempotent
+
+    - name: "IDEMPOTENT | Verify re-declaration made no change"
+      ansible.builtin.assert:
+        that:
+          - create_idempotent is not changed
+          - create_idempotent.data_connection.id == connection_id
+        fail_msg: >-
+          Re-declaring an identical connection should be a no-op. A change here
+          usually means drift detection is comparing a connector-overridden field.
+
+    # =====================================================================
+    # Phase 2: READ - Verify via info module
+    # =====================================================================
+
+    - name: "READ | Get connection by ID"
+      crowdstrike.falcon.ngsiem_data_connection_info:
+        connection_ids:
+          - "{{ connection_id }}"
+      register: info_by_id
+
+    - name: "READ | Verify info by ID"
+      ansible.builtin.assert:
+        that:
+          - info_by_id.data_connections | length == 1
+          - info_by_id.data_connections[0].id == connection_id
+          - info_by_id.data_connections[0].name == test_connection_name
+          - info_by_id.meta.pagination.total == 1
+        fail_msg: "Info lookup by ID returned unexpected data"
+
+    - name: "READ | Search connections by name filter"
+      crowdstrike.falcon.ngsiem_data_connection_info:
+        filter: "name:'{{ test_connection_name }}'"
+      register: info_by_filter
+
+    - name: "READ | Verify filter search found the connection"
+      ansible.builtin.assert:
+        that:
+          - info_by_filter.data_connections | length >= 1
+          - >-
+            info_by_filter.data_connections
+            | selectattr('id', 'equalto', connection_id)
+            | list | length == 1
+        fail_msg: "Filter search did not find the created connection"
+
+    - name: "READ | Get connection with provisioning status"
+      crowdstrike.falcon.ngsiem_data_connection_info:
+        connection_ids:
+          - "{{ connection_id }}"
+        include_status: true
+      register: info_with_status
+
+    - name: "READ | Verify provisioning_status field present"
+      ansible.builtin.assert:
+        that:
+          - info_with_status.data_connections[0].provisioning_status is defined
+        fail_msg: "provisioning_status was not included"
+
+    # =====================================================================
+    # Phase 3: UPDATE (rename) + idempotency
+    # =====================================================================
+
+    - name: "UPDATE | Rename the connection by ID"
+      crowdstrike.falcon.ngsiem_data_connection:
+        connection_id: "{{ connection_id }}"
+        name: "{{ test_connection_name }}-renamed"
+      register: update_result
+
+    - name: "UPDATE | Verify rename applied"
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.data_connection.name == test_connection_name ~ "-renamed"
+        fail_msg: "Connection rename failed"
+
+    - name: "IDEMPOTENT | Re-run update with same name"
+      crowdstrike.falcon.ngsiem_data_connection:
+        connection_id: "{{ connection_id }}"
+        name: "{{ test_connection_name }}-renamed"
+      register: idempotent_result
+
+    - name: "IDEMPOTENT | Verify no change on repeat"
+      ansible.builtin.assert:
+        that:
+          - idempotent_result is not changed
+          - idempotent_result.data_connection.id == connection_id
+        fail_msg: "Repeat update with identical params should be a no-op"
+
+    # =====================================================================
+    # Phase 4: INFO MODULE - Pagination
+    # =====================================================================
+
+    - name: "INFO | Test pagination"
+      crowdstrike.falcon.ngsiem_data_connection_info:
+        limit: 5
+        offset: 0
+      register: info_paginated
+
+    - name: "INFO | Verify pagination metadata"
+      ansible.builtin.assert:
+        that:
+          - info_paginated.meta is defined
+          - info_paginated.meta.pagination.limit == 5
+          - info_paginated.meta.pagination.offset == 0
+          - info_paginated.data_connections | length <= 5
+        fail_msg: "Pagination metadata is incorrect"
+
+    # =====================================================================
+    # Phase 5: AUTH TOKEN PASSTHROUGH
+    # =====================================================================
+
+    - name: "AUTH | Generate access token via auth module"
+      crowdstrike.falcon.auth:
+      register: falcon_auth
+
+    - name: "AUTH | Query using access token"
+      crowdstrike.falcon.ngsiem_data_connection_info:
+        auth: "{{ falcon_auth.auth }}"
+        connection_ids:
+          - "{{ connection_id }}"
+      register: auth_info
+
+    - name: "AUTH | Verify token auth query succeeded"
+      ansible.builtin.assert:
+        that:
+          - auth_info.data_connections | length == 1
+        fail_msg: "Query with token auth failed"
+
+    # =====================================================================
+    # Phase 6: DELETE + absent idempotency
+    # =====================================================================
+
+    - name: "DELETE | Remove the connection by ID"
+      crowdstrike.falcon.ngsiem_data_connection:
+        connection_id: "{{ connection_id }}"
+        state: absent
+      register: delete_result
+
+    - name: "DELETE | Verify deletion reported change"
+      ansible.builtin.assert:
+        that:
+          - delete_result is changed
+        fail_msg: "Delete did not report a change"
+
+    - name: Clear saved connection ID (successfully deleted)
+      ansible.builtin.set_fact:
+        connection_id: ""
+
+    - name: "ABSENT | Delete same connection by name again (idempotent)"
+      crowdstrike.falcon.ngsiem_data_connection:
+        name: "{{ test_connection_name }}-renamed"
+        state: absent
+      register: absent_noop
+
+    - name: "ABSENT | Verify no change for already-deleted connection"
+      ansible.builtin.assert:
+        that:
+          - absent_noop is not changed
+        fail_msg: "Absent state should be a no-op for non-existent connections"
+
+  # =======================================================================
+  # ALWAYS: Best-effort cleanup
+  # =======================================================================
+  always:
+    - name: "CLEANUP | Remove test connection by ID (if still present)"
+      crowdstrike.falcon.ngsiem_data_connection:
+        connection_id: "{{ connection_id }}"
+        state: absent
+      when: connection_id is defined and connection_id | length > 0
+      ignore_errors: true
+
+    - name: "CLEANUP | Remove test connection by original name (best-effort)"
+      crowdstrike.falcon.ngsiem_data_connection:
+        name: "{{ test_connection_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: "CLEANUP | Remove test connection by renamed name (best-effort)"
+      crowdstrike.falcon.ngsiem_data_connection:
+        name: "{{ test_connection_name }}-renamed"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
A customer asked (via #704) for a way to manage Next-Gen SIEM data connections through Ansible, so this adds three modules for it.

`ngsiem_data_connection` handles the full lifecycle: create, update, delete, and pause/resume through an `enabled` flag. `ngsiem_data_connection_info` queries existing connections by ID or FQL filter. `ngsiem_data_connector_info` lists the connector catalog so you can find the `connector_id` and `parser` values the CRUD module needs.

Two things are worth a closer look in review. PUSH connections mint an ingest token exactly once — after that the endpoint just returns "token already generated" — and it isn't ready until the connection finishes provisioning right after create. So the module polls for it (`wait_for_ingest_token`, `wait_timeout`) to catch the single response that carries the token, and returns it with the ingest URL. The typed `get_ingest_token` in FalconPy 1.6.1 is broken — it reads the dict response as a list and throws — so the token gets minted server-side and then lost in the crash, gone for good. The module goes through the raw command interface instead, which returns the response intact. The other one: idempotency only compares `name` and `parser`, because some connectors overwrite the vendor fields on create and comparing those would make the module report a change every run.

There's a new integration target under `tests/integration/targets/ngsiem_data_connection`, plus a `tests/integration/run.py` helper that stages the collection layout and loads creds from `.env` or the environment. These targets need live credentials so they don't run in CI, and the helper saves you from setting up the `ansible_collections` directory structure by hand.
