### PR TITLE
Add NG-SIEM parser modules and raise FalconPy minimum to 1.5.0

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -15,5 +15,5 @@ wheel
 ansible-rulebook
 ansible-runner
 aiohttp
-crowdstrike-falconpy>=1.4.3
+crowdstrike-falconpy>=1.6.3
 tox

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tested with the Ansible Core >= 2.15.0 versions, and the current development ver
 
 ### Python version compatibility
 
-This collection is reliant on the [CrowdStrike FalconPy SDK](https://www.falconpy.io/) for its Python interface. In line with the [Python versions supported by FalconPy](https://github.com/CrowdStrike/falconpy#supported-versions-of-python), a minimum Python version of `3.7` is required for this collection to function properly.
+This collection is reliant on the [CrowdStrike FalconPy SDK](https://www.falconpy.io/) for its Python interface. In line with the [Python versions supported by FalconPy](https://github.com/CrowdStrike/falconpy#supported-versions-of-python), a minimum Python version of `3.8` is required for this collection to function properly.
 
 > [!NOTE]
 > As of FalconPy Version 1.4.0, Python 3.6 is no longer supported. If you would like to use FalconPy with Python 3.6, please use FalconPy Version < 1.4.0.
@@ -66,6 +66,8 @@ Name | Description
 [crowdstrike.falcon.ngsiem_data_connection](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connection_module.html)|Manage NG-SIEM data connections
 [crowdstrike.falcon.ngsiem_data_connection_info](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connection_info_module.html)|Get information about NG-SIEM data connections
 [crowdstrike.falcon.ngsiem_data_connector_info](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_data_connector_info_module.html)|Get information about available NG-SIEM data connectors
+[crowdstrike.falcon.ngsiem_parser](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_parser_module.html)|Manage NG-SIEM parsers
+[crowdstrike.falcon.ngsiem_parser_info](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_parser_info_module.html)|Get information about NG-SIEM parsers
 [crowdstrike.falcon.ngsiem_search](https://crowdstrike.github.io/ansible_collection_falcon/ngsiem_search_module.html)|Execute CQL searches against Next-Gen SIEM repositories for incident response and threat hunting
 [crowdstrike.falcon.sensor_download](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_module.html)|Download Falcon Sensor Installer
 [crowdstrike.falcon.sensor_download_info](https://crowdstrike.github.io/ansible_collection_falcon/sensor_download_info_module.html)|Get information about Falcon Sensor Installers

--- a/changelogs/fragments/705-add-ngsiem-parser-modules.yml
+++ b/changelogs/fragments/705-add-ngsiem-parser-modules.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ngsiem_parser - new module to create, update, clone, and delete NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
+  - ngsiem_parser_info - new module to get information about NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)

--- a/changelogs/fragments/705-bump-falconpy-minimum.yml
+++ b/changelogs/fragments/705-bump-falconpy-minimum.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Raised the enforced minimum FalconPy version from ``1.3.0`` to ``1.5.0`` across all modules, lookup plugins, and inventory plugins. Documentation now reflects a minimum of Python ``3.8`` and FalconPy ``1.5.0``.
+  - Version comparisons now use numeric tuple comparison instead of string comparison, fixing incorrect results for multi-digit versions (e.g. ``1.10.0``).

--- a/plugins/doc_fragments/credentials.py
+++ b/plugins/doc_fragments/credentials.py
@@ -62,8 +62,8 @@ options:
       - Extended headers that are prepended to the default headers dictionary.
     type: dict
 requirements:
-  - python >= 3.6
-  - crowdstrike-falconpy >= 1.3.0
+  - python >= 3.8
+  - crowdstrike-falconpy >= 1.5.0
 """
 
     AUTH = r"""

--- a/plugins/inventory/falcon_discover.py
+++ b/plugins/inventory/falcon_discover.py
@@ -67,8 +67,8 @@ options:
     default: false
 requirements:
   - Assets [B(READ)] API scope
-  - python >= 3.6
-  - crowdstrike-falconpy >= 1.3.0
+  - python >= 3.8
+  - crowdstrike-falconpy >= 1.5.0
 notes:
   - If no credentials are provided, FalconPy will attempt to use the API credentials via environment variables.
   - Hostnames are set to the C(hostname) hostvar if it exists, otherwise the IP address is used.
@@ -201,9 +201,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
 
         # Check FalconPy version
-        if _VERSION < "1.3.0":
+        if _VERSION < "1.5.0":
             raise ImportError(
-                "The crowdstrike.falcon.falcon_discover plugin requires falconpy 1.3.0 or higher."
+                "The crowdstrike.falcon.falcon_discover plugin requires falconpy 1.5.0 or higher."
             )
 
         # cache may be True or False at this point to indicate if the inventory is being refreshed

--- a/plugins/inventory/falcon_hosts.py
+++ b/plugins/inventory/falcon_hosts.py
@@ -68,8 +68,8 @@ options:
       default: ['hostname', 'external_ip', 'local_ip']
 requirements:
   - Hosts [B(READ)] API scope
-  - python >= 3.6
-  - crowdstrike-falconpy >= 1.3.0
+  - python >= 3.8
+  - crowdstrike-falconpy >= 1.5.0
 notes:
   - By default, Ansible will deduplicate the C(inventory_hostname), so if multiple hosts have the same hostname, only
     the last one will be used. In this case, consider using the C(device_id) as the first preference in the C(hostnames).
@@ -206,9 +206,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
 
         # Check FalconPy version
-        if _VERSION < "1.3.0":
+        if _VERSION < "1.5.0":
             raise ImportError(
-                "The crowdstrike.falcon.falcon_hosts plugin requires falconpy 1.3.0 or higher."
+                "The crowdstrike.falcon.falcon_hosts plugin requires falconpy 1.5.0 or higher."
             )
 
         # cache may be True or False at this point to indicate if the inventory is being refreshed

--- a/plugins/module_utils/falconpy_utils.py
+++ b/plugins/module_utils/falconpy_utils.py
@@ -21,16 +21,29 @@ except (ImportError, ModuleNotFoundError) as e:
 __metaclass__ = type
 
 
-def check_falconpy_version(module):
-    """Ensure FalconPy version is compatible."""
-    minimum_version = "1.3.0"
+def _version_tuple(version):
+    """Convert a dotted version string to a tuple of ints for safe comparison.
 
+    String comparison is lexicographically wrong for multi-digit versions
+    (e.g. "1.10.0" < "1.6.3" is True), so compare numerically instead.
+    """
+    return tuple(int(part) for part in version.split("."))
+
+
+def check_falconpy_version(module, minimum_version="1.5.0"):
+    """Ensure FalconPy version is compatible.
+
+    Args:
+        module: The AnsibleModule instance (used for fail_json).
+        minimum_version: The minimum required FalconPy version. Defaults to the
+            global floor; modules needing newer methods can require more.
+    """
     if FALCONPY_IMPORT_ERROR:
         module.fail_json(
             msg=f"Unable to import FalconPy: {FALCONPY_IMPORT_ERROR}. See module documentation for help."
         )
 
-    if _VERSION < minimum_version:
+    if _version_tuple(_VERSION) < _version_tuple(minimum_version):
         module.fail_json(
             msg=f"Unsupported FalconPy version: {_VERSION}. Upgrade to {minimum_version} or higher."
         )

--- a/plugins/modules/ngsiem_parser.py
+++ b/plugins/modules/ngsiem_parser.py
@@ -1,0 +1,511 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ngsiem_parser
+
+short_description: Manage NG-SIEM parsers
+
+version_added: "4.13.0"
+
+description:
+  - Create, update, clone, and delete custom NG-SIEM parsers in the CrowdStrike
+    Falcon platform.
+  - Parsers transform raw log data into normalized events for Next-Gen SIEM.
+  - Custom parsers are managed through LogScale YAML templates. Provide the full
+    template via I(parser_yaml) for create and update operations.
+  - Supports idempotent operations that only make changes when the meaningful
+    parser content differs from what is already stored.
+  - Use M(crowdstrike.falcon.ngsiem_parser_info) to discover existing parsers and
+    retrieve their definitions.
+
+options:
+  state:
+    description:
+      - The desired state of the parser.
+      - C(present) ensures the parser exists with the specified content.
+      - C(absent) ensures the parser does not exist.
+    type: str
+    choices: ["present", "absent"]
+    default: present
+  repository:
+    description:
+      - The name of the repository the parser belongs to.
+    type: str
+    default: parsers-repository
+  name:
+    description:
+      - The name of the parser.
+      - Required when creating a new parser and when using I(clone_from) or
+        I(extension_of).
+      - Used to look up an existing parser when I(parser_id) is not provided.
+    type: str
+    required: false
+  parser_id:
+    description:
+      - The version-suffixed ID of an existing parser (e.g. C(abc123:1.0.0)).
+      - Preferred for identifying an existing parser during update or delete.
+      - When provided with I(state=absent), the parser is deleted by ID.
+    type: str
+    required: false
+  parser_yaml:
+    description:
+      - The full LogScale parser YAML template.
+      - Required when creating or updating a parser via I(state=present) unless
+        I(clone_from) or I(extension_of) is used.
+      - For idempotency, the module compares the C(script), C(tagFields), and
+        C(testCases) of this template against the stored parser and only updates
+        when they differ.
+    type: str
+    required: false
+  clone_from:
+    description:
+      - The ID of a source parser to clone into a new parser named I(name).
+      - Mutually exclusive with I(parser_yaml) and I(extension_of).
+      - Only applies when the target parser (I(name)) does not already exist.
+    type: str
+    required: false
+  extension_of:
+    description:
+      - The unversioned base parser ID to create an extension of, named I(name).
+      - "B(Note:) The base parser ID must be B(unversioned) (no C(:x.y.z) suffix)."
+      - Mutually exclusive with I(parser_yaml) and I(clone_from).
+      - Only applies when the target parser (I(name)) does not already exist.
+    type: str
+    required: false
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+notes:
+  - B(Idempotency:) For I(state=present) with I(parser_yaml), the module fetches
+    the current parser template and compares C(script), C(tagFields), and
+    C(testCases) semantically (ignoring whitespace and the auto-incremented
+    version). Perfect round-trip idempotency is not guaranteed because the server
+    normalizes stored scripts; a re-run may report a change if the server
+    reformats content.
+  - B(Versioning:) Custom parsers auto-increment their version on each update or
+    clone. The returned parser ID is version-suffixed and will differ from the
+    input ID after an update.
+  - B(Parser Lookup:) When I(parser_id) is not provided, the module searches by
+    exact I(name). Prefer I(parser_id) for precise targeting.
+  - B(State Management:) For I(state=absent), if the parser is not found, the
+    module exits successfully without making any changes (idempotent). A stale
+    index entry that 404s on delete is treated as already absent.
+  - B(Check mode:) In check mode the module reports the intended change without
+    mutating the parser.
+
+requirements:
+  - NGSIEM Parsers [B(READ), B(WRITE)] API scope
+  - CrowdStrike FalconPy >= 1.6.3
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Create a custom parser from a YAML template
+  crowdstrike.falcon.ngsiem_parser:
+    name: my-custom-parser
+    parser_yaml: "{{ lookup('file', 'my-parser.yaml') }}"
+
+- name: Update a parser (idempotent - only changes when content differs)
+  crowdstrike.falcon.ngsiem_parser:
+    name: my-custom-parser
+    parser_yaml: "{{ lookup('file', 'my-parser-v2.yaml') }}"
+
+- name: Clone an existing parser into a new one
+  crowdstrike.falcon.ngsiem_parser:
+    name: my-cloned-parser
+    clone_from: "10f55deaa2893f60b87af305f44f80bf:1.0.0"
+
+- name: Create an extension of a base parser (base ID must be unversioned)
+  crowdstrike.falcon.ngsiem_parser:
+    name: my-parser-extension
+    extension_of: "10f55deaa2893f60b87af305f44f80bf"
+
+- name: Delete a parser by name
+  crowdstrike.falcon.ngsiem_parser:
+    name: my-custom-parser
+    state: absent
+
+- name: Delete a parser by ID
+  crowdstrike.falcon.ngsiem_parser:
+    parser_id: "10f55deaa2893f60b87af305f44f80bf:1.1.0"
+    state: absent
+"""
+
+RETURN = r"""
+parser:
+  description:
+    - Information about the parser that was created, updated, or cloned.
+  type: dict
+  returned: when state=present and a parser exists
+  contains:
+    id:
+      description: The version-suffixed unique identifier of the parser.
+      type: str
+      returned: success
+      sample: "10f55deaa2893f60b87af305f44f80bf:1.1.0"
+    name:
+      description: The name of the parser.
+      type: str
+      returned: success
+      sample: "my-custom-parser"
+    script:
+      description: The LogScale/CQL parsing script.
+      type: str
+      returned: success
+    fields_to_tag:
+      description: The list of fields to tag on parsed events.
+      type: list
+      returned: success
+    test_cases:
+      description: The list of test cases associated with the parser.
+      type: list
+      returned: success
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import NGSIEM
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+YAML_IMPORT_ERROR = None
+try:
+    import yaml
+
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+    YAML_IMPORT_ERROR = traceback.format_exc()
+
+# The parser modules require the typed clone/extension methods added in 1.6.3.
+MINIMUM_FALCONPY_VERSION = "1.6.3"
+
+NGSIEM_PARSER_ARGS = {
+    "state": {"type": "str", "choices": ["present", "absent"], "default": "present"},
+    "repository": {"type": "str", "default": "parsers-repository"},
+    "name": {"type": "str", "required": False},
+    "parser_id": {"type": "str", "required": False},
+    "parser_yaml": {"type": "str", "required": False},
+    "clone_from": {"type": "str", "required": False},
+    "extension_of": {"type": "str", "required": False},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(NGSIEM_PARSER_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    state = module.params["state"]
+    name = module.params.get("name")
+    parser_id = module.params.get("parser_id")
+
+    if not name and not parser_id:
+        module.fail_json(msg="Either 'name' or 'parser_id' is required")
+
+    if state == "present":
+        creation_inputs = [
+            module.params.get("parser_yaml"),
+            module.params.get("clone_from"),
+            module.params.get("extension_of"),
+        ]
+        provided = [i for i in creation_inputs if i]
+        if len(provided) > 1:
+            module.fail_json(
+                msg="'parser_yaml', 'clone_from', and 'extension_of' are mutually exclusive"
+            )
+
+        if (module.params.get("clone_from") or module.params.get("extension_of")) and not name:
+            module.fail_json(
+                msg="'name' is required when using 'clone_from' or 'extension_of'"
+            )
+
+
+def find_parser_by_name(falcon, module, name):
+    """Find a parser by exact name via the substring filter, then exact match."""
+    result = falcon.list_parsers(
+        repository=module.params["repository"],
+        filter=f"name:~'{name}'",
+        limit=100,
+    )
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        for item in result["body"]["resources"]:
+            if item.get("Name") == name:
+                return item
+    return None
+
+
+def get_parser_by_id(falcon, module, parser_id):
+    """Get a parser summary by ID from the list endpoint."""
+    result = falcon.list_parsers(
+        repository=module.params["repository"],
+        limit=500,
+    )
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        for item in result["body"]["resources"]:
+            if item.get("ID") == parser_id:
+                return item
+    return None
+
+
+def resolve_existing(falcon, module):
+    """Resolve the current parser (summary dict) by parser_id or name."""
+    parser_id = module.params.get("parser_id")
+    name = module.params.get("name")
+
+    if parser_id:
+        return get_parser_by_id(falcon, module, parser_id)
+    if name:
+        return find_parser_by_name(falcon, module, name)
+    return None
+
+
+def get_template_yaml(falcon, module, parser_id):
+    """Fetch the stored YAML template for a parser ID."""
+    result = falcon.get_parser_template(
+        ids=parser_id, repository=module.params["repository"]
+    )
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0].get("yaml_template")
+    return None
+
+
+def _semantic_content(yaml_text):
+    """Extract the meaningful, comparable content from a parser YAML template.
+
+    Returns a normalized tuple of (script, tagFields, testCases) with whitespace
+    stripped from the script. The auto-incremented version and schema/name are
+    intentionally excluded so idempotency keys on the actual parser logic.
+    """
+    parsed = yaml.safe_load(yaml_text) or {}
+    script = (parsed.get("script") or "").strip()
+    tag_fields = parsed.get("tagFields") or []
+    test_cases = parsed.get("testCases") or []
+    return script, tag_fields, test_cases
+
+
+def parser_needs_update(current_yaml, desired_yaml):
+    """Compare stored vs desired YAML on script + tagFields + testCases."""
+    if not current_yaml:
+        return True
+    return _semantic_content(current_yaml) != _semantic_content(desired_yaml)
+
+
+def _extract_parser_id(body):
+    """Pull a parser ID out of a create/clone/update response body.
+
+    Clone returns ``resources`` as a dict ``{id, name}``; the template methods
+    return a list. Handle both shapes.
+    """
+    resources = body.get("resources")
+    if isinstance(resources, dict):
+        return resources.get("id")
+    if isinstance(resources, list) and resources:
+        first = resources[0]
+        if isinstance(first, dict):
+            return first.get("id")
+        return first
+    return None
+
+
+def build_parser_result(falcon, module, parser_id):
+    """Build the returned parser dict from the full definition."""
+    result = falcon.get_parser(ids=parser_id, repository=module.params["repository"])
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0]
+    return {"id": parser_id}
+
+
+def create_from_template(falcon, module):
+    """Create a new parser from the provided YAML template."""
+    return falcon.create_parser_from_template(
+        repository=module.params["repository"],
+        name=module.params["name"],
+        yaml_template=module.params["parser_yaml"],
+    )
+
+
+def update_from_template(falcon, module, parser_id):
+    """Update an existing parser from the provided YAML template."""
+    return falcon.update_parser_from_template(
+        ids=parser_id,
+        repository=module.params["repository"],
+        yaml_template=module.params["parser_yaml"],
+    )
+
+
+def clone_parser(falcon, module):
+    """Clone a source parser into a new parser named 'name'."""
+    return falcon.clone_parser(
+        source_id=module.params["clone_from"],
+        new_name=module.params["name"],
+    )
+
+
+def create_extension(falcon, module):
+    """Create an extension of a base parser."""
+    return falcon.create_parser_extension(
+        base_parser_id=module.params["extension_of"],
+        extension_name=module.params["name"],
+    )
+
+
+def handle_present(falcon, module, result):
+    """Handle state=present (create, update, clone, or extension)."""
+    current = resolve_existing(falcon, module)
+
+    if module.params.get("parser_id") and not current:
+        module.fail_json(
+            msg=f"Parser with ID '{module.params['parser_id']}' not found"
+        )
+
+    if current:
+        current_id = current.get("ID") or current.get("id")
+
+        # Clone/extension only apply when creating a new parser; an existing
+        # parser with the target name is left as-is for those inputs.
+        if module.params.get("parser_yaml"):
+            current_yaml = get_template_yaml(falcon, module, current_id)
+            if parser_needs_update(current_yaml, module.params["parser_yaml"]):
+                if module.check_mode:
+                    result["changed"] = True
+                    result["parser"] = current
+                    return
+                update_result = update_from_template(falcon, module, current_id)
+                if update_result["status_code"] not in (200, 201):
+                    handle_return_errors(module, result, update_result)
+                result["changed"] = True
+                new_id = _extract_parser_id(update_result["body"]) or current_id
+                result["parser"] = build_parser_result(falcon, module, new_id)
+                return
+
+        result["parser"] = build_parser_result(falcon, module, current_id)
+        return
+
+    # No existing parser - create it.
+    if module.check_mode:
+        result["changed"] = True
+        return
+
+    if module.params.get("clone_from"):
+        create_result = clone_parser(falcon, module)
+    elif module.params.get("extension_of"):
+        create_result = create_extension(falcon, module)
+    elif module.params.get("parser_yaml"):
+        create_result = create_from_template(falcon, module)
+    else:
+        module.fail_json(
+            msg="One of 'parser_yaml', 'clone_from', or 'extension_of' is "
+            "required to create a parser"
+        )
+        return
+
+    if create_result["status_code"] not in (200, 201):
+        handle_return_errors(module, result, create_result)
+
+    new_id = _extract_parser_id(create_result["body"])
+    if new_id:
+        result["changed"] = True
+        result["parser"] = build_parser_result(falcon, module, new_id)
+
+
+def handle_absent(falcon, module, result):
+    """Handle state=absent (delete)."""
+    current = resolve_existing(falcon, module)
+
+    if not current:
+        return
+
+    parser_id = current.get("ID") or current.get("id")
+
+    if module.check_mode:
+        result["changed"] = True
+        return
+
+    delete_result = falcon.delete_parser(
+        ids=parser_id, repository=module.params["repository"]
+    )
+    status = delete_result["status_code"]
+    if status == 404:
+        # Stale index entry - treat as already absent (idempotent).
+        return
+    if status not in (200, 202):
+        handle_return_errors(module, result, delete_result)
+    result["changed"] = True
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    if not HAS_YAML:
+        module.fail_json(
+            msg=missing_required_lib("PyYAML"), exception=YAML_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module, minimum_version=MINIMUM_FALCONPY_VERSION)
+    validate_params(module)
+
+    result = dict(
+        changed=False,
+    )
+
+    falcon = authenticate(module, NGSIEM)
+
+    try:
+        if module.params["state"] == "present":
+            handle_present(falcon, module, result)
+        else:
+            handle_absent(falcon, module, result)
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while managing the parser: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ngsiem_parser_info.py
+++ b/plugins/modules/ngsiem_parser_info.py
@@ -1,0 +1,409 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, CrowdStrike Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ngsiem_parser_info
+
+short_description: Get information about NG-SIEM parsers
+
+version_added: "4.13.0"
+
+description:
+  - Returns detailed information for one or more NG-SIEM parsers in the
+    CrowdStrike Falcon platform.
+  - Parsers transform raw log data into normalized events for Next-Gen SIEM.
+    They come in two types - built-in B(ootb) (out-of-the-box) parsers shipped
+    by CrowdStrike, and B(custom) parsers created in your tenant.
+  - By default the full parser definition (including the C(script),
+    C(fields_to_tag), and C(test_cases)) is returned for each parser. Set
+    I(definitions=false) to return only the lightweight list metadata.
+  - Use M(crowdstrike.falcon.ngsiem_parser) to create, update, clone, or delete
+    parsers.
+
+options:
+  parser_ids:
+    description:
+      - A list of parser IDs to get information about.
+      - Parser IDs are version-suffixed (e.g. C(abc123:1.0.0)).
+      - When provided, I(name), I(parser_type), and I(update_available) filters
+        are ignored.
+    type: list
+    elements: str
+    required: false
+  name:
+    description:
+      - Substring to match against parser names.
+      - This maps to the only supported parser query filter (C(name:~'value')),
+        which performs a case-insensitive substring match.
+    type: str
+    required: false
+  parser_type:
+    description:
+      - Filter parsers by type.
+      - C(ootb) returns only built-in (out-of-the-box) parsers.
+      - C(custom) returns only custom parsers created in your tenant.
+    type: str
+    choices: ["ootb", "custom"]
+    required: false
+  update_available:
+    description:
+      - Filter parsers by whether a newer version is available.
+    type: bool
+    required: false
+  definitions:
+    description:
+      - Whether to fetch the full definition for each parser.
+      - When C(true) (default), an additional API call is made per parser to
+        return its C(script), C(fields_to_tag), C(test_cases), and other
+        definition fields.
+      - When C(false), only the lightweight list metadata is returned.
+    type: bool
+    default: true
+  limit:
+    description:
+      - Maximum number of parsers to return.
+      - Must be between 1 and 500.
+    type: int
+    default: 100
+  offset:
+    description:
+      - Starting index for pagination.
+      - Use with I(limit) to paginate through large result sets.
+    type: int
+    default: 0
+  repository:
+    description:
+      - The name of the repository to query.
+    type: str
+    default: parsers-repository
+
+extends_documentation_fragment:
+  - crowdstrike.falcon.credentials
+  - crowdstrike.falcon.credentials.auth
+
+notes:
+  - B(Filtering:) Only substring matching on I(name) is supported by the API.
+    General FQL expressions are not supported. Non-name filters (I(parser_type),
+    I(update_available)) are applied as dedicated query parameters.
+
+requirements:
+  - NGSIEM Parsers [B(READ)] API scope
+  - CrowdStrike FalconPy >= 1.6.3
+
+author:
+  - Carlos Matos (@carlosmmatos)
+"""
+
+EXAMPLES = r"""
+- name: Get all parsers with full definitions
+  crowdstrike.falcon.ngsiem_parser_info:
+
+- name: Get only custom parsers
+  crowdstrike.falcon.ngsiem_parser_info:
+    parser_type: custom
+
+- name: Get parsers whose name contains 'watchguard'
+  crowdstrike.falcon.ngsiem_parser_info:
+    name: watchguard
+
+- name: Get specific parsers by ID
+  crowdstrike.falcon.ngsiem_parser_info:
+    parser_ids:
+      - "10f55deaa2893f60b87af305f44f80bf:1.0.0"
+
+- name: List parsers that have an update available (metadata only)
+  crowdstrike.falcon.ngsiem_parser_info:
+    update_available: true
+    definitions: false
+
+- name: Get custom parsers using metadata only for a quick inventory
+  crowdstrike.falcon.ngsiem_parser_info:
+    parser_type: custom
+    definitions: false
+    limit: 50
+"""
+
+RETURN = r"""
+parsers:
+  description:
+    - A list of parsers that match the search criteria.
+    - When I(definitions=true) (default), each entry includes the full parser
+      definition merged with its list metadata.
+  type: list
+  returned: success
+  elements: dict
+  contains:
+    id:
+      description: The version-suffixed unique identifier of the parser.
+      type: str
+      returned: success
+      sample: "10f55deaa2893f60b87af305f44f80bf:1.0.0"
+    name:
+      description: The name of the parser.
+      type: str
+      returned: success
+      sample: "redhat-insights"
+    parser_type:
+      description: The type of the parser (ootb or custom).
+      type: str
+      returned: success
+      sample: "custom"
+    current_version:
+      description: The currently installed version of the parser.
+      type: str
+      returned: success
+      sample: "1.0.0"
+    latest_version:
+      description: The latest available version of the parser.
+      type: str
+      returned: success
+      sample: "1.0.0"
+    update_available:
+      description: Whether a newer version of the parser is available.
+      type: bool
+      returned: success
+      sample: false
+    description:
+      description: The description of the parser.
+      type: str
+      returned: when definitions=true
+    is_built_in:
+      description: Whether the parser is a built-in (out-of-the-box) parser.
+      type: bool
+      returned: when definitions=true
+    script:
+      description: The LogScale/CQL parsing script.
+      type: str
+      returned: when definitions=true
+    fields_to_tag:
+      description: The list of fields to tag on parsed events.
+      type: list
+      returned: when definitions=true
+    test_cases:
+      description: The list of test cases associated with the parser.
+      type: list
+      returned: when definitions=true
+meta:
+  description: Metadata about the query results.
+  type: dict
+  returned: success
+  contains:
+    query_time:
+      description: Time taken to execute the query in seconds.
+      type: float
+      returned: success
+      sample: 0.123
+    pagination:
+      description: Pagination information.
+      type: dict
+      returned: success
+      contains:
+        offset:
+          description: The starting index used for this query.
+          type: int
+          returned: success
+          sample: 0
+        limit:
+          description: The limit used for this query.
+          type: int
+          returned: success
+          sample: 100
+        total:
+          description: Total number of parsers matching the query.
+          type: int
+          returned: success
+          sample: 42
+"""
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.common_args import (
+    falconpy_arg_spec,
+)
+from ansible_collections.crowdstrike.falcon.plugins.module_utils.falconpy_utils import (
+    authenticate,
+    check_falconpy_version,
+    handle_return_errors,
+)
+
+FALCONPY_IMPORT_ERROR = None
+try:
+    from falconpy import NGSIEM
+
+    HAS_FALCONPY = True
+except ImportError:
+    HAS_FALCONPY = False
+    FALCONPY_IMPORT_ERROR = traceback.format_exc()
+
+# The parser modules require the typed clone/extension methods added in 1.6.3.
+MINIMUM_FALCONPY_VERSION = "1.6.3"
+
+NGSIEM_PARSER_INFO_ARGS = {
+    "parser_ids": {"type": "list", "elements": "str", "required": False},
+    "name": {"type": "str", "required": False},
+    "parser_type": {"type": "str", "choices": ["ootb", "custom"], "required": False},
+    "update_available": {"type": "bool", "required": False},
+    "definitions": {"type": "bool", "default": True},
+    "limit": {"type": "int", "default": 100},
+    "offset": {"type": "int", "default": 0},
+    "repository": {"type": "str", "default": "parsers-repository"},
+}
+
+
+def argspec():
+    """Define the module's argument spec."""
+    args = falconpy_arg_spec()
+    args.update(NGSIEM_PARSER_INFO_ARGS)
+
+    return args
+
+
+def validate_params(module):
+    """Validate module parameters."""
+    limit = module.params["limit"]
+    if limit < 1 or limit > 500:
+        module.fail_json(msg="Parameter 'limit' must be between 1 and 500")
+
+    offset = module.params["offset"]
+    if offset < 0:
+        module.fail_json(msg="Parameter 'offset' must be 0 or greater")
+
+
+def list_parsers(falcon, module):
+    """List parsers using filters and pagination."""
+    params = {
+        "repository": module.params["repository"],
+        "limit": module.params["limit"],
+        "offset": module.params["offset"],
+    }
+
+    if module.params.get("name"):
+        params["filter"] = f"name:~'{module.params['name']}'"
+
+    if module.params.get("parser_type"):
+        params["parser_type"] = module.params["parser_type"]
+
+    if module.params.get("update_available") is not None:
+        params["update_available"] = str(module.params["update_available"]).lower()
+
+    return falcon.list_parsers(**params)
+
+
+def normalize_summary(item):
+    """Normalize a list-parser summary item to lowercase-keyed fields.
+
+    The list endpoint returns ``ID``/``Name`` (capitalized) while the get
+    endpoint returns ``id``/``name``. Normalize to the lowercase form so the
+    returned data is consistent regardless of I(definitions).
+    """
+    summary = dict(item)
+    if "ID" in summary:
+        summary["id"] = summary.pop("ID")
+    if "Name" in summary:
+        summary["name"] = summary.pop("Name")
+    return summary
+
+
+def get_parser_definition(falcon, repository, parser_id):
+    """Fetch the full definition for a single parser ID."""
+    result = falcon.get_parser(ids=parser_id, repository=repository)
+    if result["status_code"] == 200 and result["body"].get("resources"):
+        return result["body"]["resources"][0]
+    return None
+
+
+def main():
+    """Entry point for module execution."""
+    module = AnsibleModule(
+        argument_spec=argspec(),
+        supports_check_mode=True,
+    )
+
+    if not HAS_FALCONPY:
+        module.fail_json(
+            msg=missing_required_lib("falconpy"), exception=FALCONPY_IMPORT_ERROR
+        )
+
+    check_falconpy_version(module, minimum_version=MINIMUM_FALCONPY_VERSION)
+    validate_params(module)
+
+    start_time = time.time()
+    repository = module.params["repository"]
+    parsers = []
+    total = 0
+    falcon = authenticate(module, NGSIEM)
+
+    result = dict(
+        changed=False,
+        parsers=[],
+        meta={},
+    )
+
+    query_result = None
+
+    try:
+        parser_ids = module.params.get("parser_ids")
+
+        if parser_ids:
+            # Build lightweight summaries from the explicit IDs; definitions are
+            # fetched below when requested.
+            parsers = [{"id": pid} for pid in parser_ids]
+            total = len(parsers)
+        else:
+            query_result = list_parsers(falcon, module)
+            if query_result["status_code"] == 200:
+                summaries = query_result["body"].get("resources") or []
+                parsers = [normalize_summary(item) for item in summaries]
+                meta = query_result["body"].get("meta", {})
+                total = meta.get("pagination", {}).get("total", len(parsers))
+            else:
+                handle_return_errors(module, result, query_result)
+
+        if module.params["definitions"]:
+            enriched = []
+            for parser in parsers:
+                definition = get_parser_definition(falcon, repository, parser["id"])
+                if definition:
+                    # Definition fields take precedence but retain summary-only
+                    # metadata (parser_type, versions, update_available).
+                    merged = dict(parser)
+                    merged.update(definition)
+                    enriched.append(merged)
+                else:
+                    enriched.append(parser)
+            parsers = enriched
+
+        result["parsers"] = parsers
+        result["meta"] = {
+            "query_time": time.time() - start_time,
+            "pagination": {
+                "offset": module.params["offset"],
+                "limit": module.params["limit"],
+                "total": total,
+            },
+        }
+
+        if query_result is not None:
+            handle_return_errors(module, result, query_result)
+
+    except Exception as e:
+        module.fail_json(
+            msg=f"An error occurred while retrieving parser information: {str(e)}",
+            **result,
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/plugin_utils/falconpy_utils.py
+++ b/plugins/plugin_utils/falconpy_utils.py
@@ -23,8 +23,17 @@ except ImportError:
     _VERSION = None
     FALCONPY_IMPORT_ERROR = traceback.format_exc()
 
-MINIMUM_FALCONPY_VERSION = "1.3.0"
+MINIMUM_FALCONPY_VERSION = "1.5.0"
 VALID_CLOUDS = ["us-1", "us-2", "eu-1", "us-gov-1", "us-gov-2"]
+
+
+def _version_tuple(version):
+    """Convert a dotted version string to a tuple of ints for safe comparison.
+
+    String comparison is lexicographically wrong for multi-digit versions
+    (e.g. "1.10.0" < "1.6.3" is True), so compare numerically instead.
+    """
+    return tuple(int(part) for part in version.split("."))
 
 
 def check_falconpy(plugin_name):
@@ -42,7 +51,7 @@ def check_falconpy(plugin_name):
             "library is not installed."
         )
 
-    if _VERSION < MINIMUM_FALCONPY_VERSION:
+    if _version_tuple(_VERSION) < _version_tuple(MINIMUM_FALCONPY_VERSION):
         raise AnsibleError(
             f"Unsupported FalconPy version: {_VERSION}. "
             f"Upgrade to {MINIMUM_FALCONPY_VERSION} or higher."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-crowdstrike-falconpy==1.4.1
+crowdstrike-falconpy>=1.6.3

--- a/tests/integration/targets/ngsiem_parser/aliases
+++ b/tests/integration/targets/ngsiem_parser/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ngsiem_parser/tasks/main.yml
+++ b/tests/integration/targets/ngsiem_parser/tasks/main.yml
@@ -1,0 +1,288 @@
+---
+# Integration tests for ngsiem_parser and ngsiem_parser_info modules
+#
+# Requirements:
+#   FALCON_CLIENT_ID     - API client ID
+#   FALCON_CLIENT_SECRET - API client secret
+#   FALCON_CLOUD         - Falcon cloud region (optional, defaults to us-1)
+#
+# API scopes: NGSIEM Parsers [READ, WRITE]
+#
+# Custom parsers auto-increment their version on each update/clone, so the
+# returned parser ID is version-suffixed and changes after an update. These
+# tests key idempotency on parser content, not on the ID.
+
+- name: Validate required environment variables
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'FALCON_CLIENT_ID') | length > 0
+      - lookup('env', 'FALCON_CLIENT_SECRET') | length > 0
+    fail_msg: "FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables must be set"
+
+- name: Set test variables
+  ansible.builtin.set_fact:
+    test_parser_name: "ansible-int-parser"
+    test_clone_name: "ansible-int-clone"
+    test_ext_name: "ansible-int-ext"
+    # A minimal valid parser. The script must emit all mandatory tag fields and
+    # tagFields must enumerate every one of them, or create returns 400.
+    test_parser_yaml: |
+      $schema: https://schemas.humio.com/parser/v0.3.0
+      name: ansible-int-parser
+      fieldsToBeRemovedBeforeParsing: []
+      testCases: []
+      script: |-
+        parseJson()
+        | Cps.version := "1.0.0"
+        | Vendor := "ansible"
+        | ecs.version := "9.0.0"
+        | event.dataset := "ansible.test"
+        | event.kind := "event"
+        | event.module := "ansible"
+        | event.outcome := "success"
+        | observer.type := "test"
+      tagFields:
+        - Cps.version
+        - Vendor
+        - ecs.version
+        - event.dataset
+        - event.kind
+        - event.module
+        - event.outcome
+        - observer.type
+
+- name: Run CRUD lifecycle tests
+  block:
+    # =====================================================================
+    # Phase 1: CREATE
+    # =====================================================================
+
+    - name: "CREATE | Create a custom parser from a YAML template"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_parser_name }}"
+        parser_yaml: "{{ test_parser_yaml }}"
+      register: create_result
+
+    - name: "CREATE | Verify parser was created"
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - create_result.parser is defined
+          - create_result.parser.name == test_parser_name
+          - create_result.parser.id | length > 0
+          - create_result.parser.script is defined
+        fail_msg: "Parser creation failed or returned unexpected data"
+
+    - name: Save parser ID
+      ansible.builtin.set_fact:
+        parser_id: "{{ create_result.parser.id }}"
+
+    # =====================================================================
+    # Phase 2: READ - Verify via info module
+    # =====================================================================
+
+    - name: "READ | Get parser by ID with full definition"
+      crowdstrike.falcon.ngsiem_parser_info:
+        parser_ids:
+          - "{{ parser_id }}"
+      register: info_by_id
+
+    - name: "READ | Verify info by ID"
+      ansible.builtin.assert:
+        that:
+          - info_by_id.parsers | length == 1
+          - info_by_id.parsers[0].id == parser_id
+          - info_by_id.parsers[0].name == test_parser_name
+          - info_by_id.parsers[0].script is defined
+        fail_msg: "Info lookup by ID returned unexpected data"
+
+    - name: "READ | Search parsers by name substring"
+      crowdstrike.falcon.ngsiem_parser_info:
+        name: "ansible-int-parser"
+        parser_type: custom
+      register: info_by_name
+
+    - name: "READ | Verify name search found the parser"
+      ansible.builtin.assert:
+        that:
+          - >-
+            info_by_name.parsers
+            | selectattr('name', 'equalto', test_parser_name)
+            | list | length == 1
+        fail_msg: "Name search did not find the created parser"
+
+    - name: "READ | List custom parsers metadata only (no definitions)"
+      crowdstrike.falcon.ngsiem_parser_info:
+        parser_type: custom
+        definitions: false
+      register: info_metadata
+
+    - name: "READ | Verify metadata-only results omit script"
+      ansible.builtin.assert:
+        that:
+          - info_metadata.parsers | length >= 1
+          - info_metadata.meta.pagination is defined
+        fail_msg: "Metadata-only listing returned unexpected data"
+
+    # =====================================================================
+    # Phase 3: IDEMPOTENCY - Re-run with identical content
+    # =====================================================================
+
+    - name: "IDEMPOTENT | Re-run create with identical YAML"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_parser_name }}"
+        parser_yaml: "{{ test_parser_yaml }}"
+      register: idempotent_result
+
+    - name: "IDEMPOTENT | Verify no change for identical content"
+      ansible.builtin.assert:
+        that:
+          - idempotent_result is not changed
+        fail_msg: "Module should not report a change when content is unchanged"
+
+    # =====================================================================
+    # Phase 4: CHECK MODE
+    # =====================================================================
+
+    - name: "CHECK | Delete in check mode (should report change, not mutate)"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_parser_name }}"
+        state: absent
+      check_mode: true
+      register: check_delete
+
+    - name: "CHECK | Verify check mode reported intended change"
+      ansible.builtin.assert:
+        that:
+          - check_delete is changed
+        fail_msg: "Check mode should report a change without mutating"
+
+    - name: "CHECK | Confirm parser still exists after check-mode delete"
+      crowdstrike.falcon.ngsiem_parser_info:
+        parser_ids:
+          - "{{ parser_id }}"
+      register: check_still_there
+
+    - name: "CHECK | Verify parser was not actually deleted"
+      ansible.builtin.assert:
+        that:
+          - check_still_there.parsers | length == 1
+        fail_msg: "Check mode must not delete the parser"
+
+    # =====================================================================
+    # Phase 5: CLONE
+    # =====================================================================
+
+    - name: "CLONE | Clone the parser into a new one"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_clone_name }}"
+        clone_from: "{{ parser_id }}"
+      register: clone_result
+
+    - name: "CLONE | Verify clone was created"
+      ansible.builtin.assert:
+        that:
+          - clone_result is changed
+          - clone_result.parser.name == test_clone_name
+          - clone_result.parser.id | length > 0
+        fail_msg: "Clone failed or returned unexpected data"
+
+    # =====================================================================
+    # Phase 6: EXTENSION (requires a CrowdStrike-managed OOTB base parser)
+    # =====================================================================
+
+    - name: "EXT | Find an OOTB parser to extend"
+      crowdstrike.falcon.ngsiem_parser_info:
+        parser_type: ootb
+        definitions: false
+        limit: 1
+      register: ootb_parsers
+
+    - name: "EXT | Create an extension of the OOTB base parser (unversioned ID)"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_ext_name }}"
+        extension_of: "{{ ootb_parsers.parsers[0].id | regex_replace(':.*$', '') }}"
+      register: ext_result
+      when: ootb_parsers.parsers | length > 0
+
+    - name: "EXT | Verify extension was created"
+      ansible.builtin.assert:
+        that:
+          - ext_result is changed
+          - ext_result.parser.id | length > 0
+        fail_msg: "Extension creation failed"
+      when: ootb_parsers.parsers | length > 0
+
+    # =====================================================================
+    # Phase 7: AUTH TOKEN PASSTHROUGH
+    # =====================================================================
+
+    - name: "AUTH | Generate access token via auth module"
+      crowdstrike.falcon.auth:
+      register: falcon_auth
+
+    - name: "AUTH | Query using access token"
+      crowdstrike.falcon.ngsiem_parser_info:
+        auth: "{{ falcon_auth.auth }}"
+        parser_ids:
+          - "{{ parser_id }}"
+      register: auth_info
+
+    - name: "AUTH | Verify token auth query succeeded"
+      ansible.builtin.assert:
+        that:
+          - auth_info.parsers | length == 1
+        fail_msg: "Query with token auth failed"
+
+    # =====================================================================
+    # Phase 8: ABSENT IDEMPOTENCY (non-existent parser)
+    # =====================================================================
+
+    - name: "ABSENT | Delete non-existent parser by name (idempotent)"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "ansible-int-does-not-exist-999999"
+        state: absent
+      register: absent_noop
+
+    - name: "ABSENT | Verify no change for non-existent parser"
+      ansible.builtin.assert:
+        that:
+          - absent_noop is not changed
+        fail_msg: "Absent state should be a no-op for non-existent parsers"
+
+    # =====================================================================
+    # Phase 9: DELETE
+    # =====================================================================
+
+    - name: "DELETE | Remove the parser by name"
+      crowdstrike.falcon.ngsiem_parser:
+        name: "{{ test_parser_name }}"
+        state: absent
+      register: delete_result
+
+    - name: "DELETE | Verify parser was deleted"
+      ansible.builtin.assert:
+        that:
+          - delete_result is changed
+        fail_msg: "Parser deletion failed"
+
+  # =======================================================================
+  # ALWAYS: Best-effort cleanup of everything this test may have created
+  # =======================================================================
+  always:
+    - name: "CLEANUP | Find any leftover test parsers"
+      crowdstrike.falcon.ngsiem_parser_info:
+        name: "ansible-int"
+        parser_type: custom
+        definitions: false
+      register: leftover_parsers
+      ignore_errors: true
+
+    - name: "CLEANUP | Delete leftover test parsers by ID"
+      crowdstrike.falcon.ngsiem_parser:
+        parser_id: "{{ item.id }}"
+        state: absent
+      loop: "{{ leftover_parsers.parsers | default([]) }}"
+      loop_control:
+        label: "{{ item.name | default(item.id) }}"
+      ignore_errors: true


### PR DESCRIPTION
Adds two modules for managing NG-SIEM parsers, and along the way bumps a FalconPy floor that had drifted well out of date.

The dependency change came first because it stood on its own. The enforced minimum was still pinned at 1.3.0 even though the newer NG-SIEM modules already needed 1.5.0, so the check and the docs disagreed. This moves the floor to 1.5.0 everywhere it's enforced — modules, lookup plugins, and both inventory plugins — and gives `check_falconpy_version` an optional `minimum_version` so a module can ask for something newer and still get a clean error instead of a raw `AttributeError`. The version check also switched from string comparison to a numeric tuple compare, since the old way decided `1.10.0 < 1.6.3`.

On top of that, two new modules:

- `ngsiem_parser_info` lists parsers and, by default, fetches each full definition so you get the script, tag fields, and test cases rather than bare IDs. Filtering matches what the API actually supports — substring match on name, plus `parser_type` and `update_available` as query params.
- `ngsiem_parser` handles create, update, clone, delete, and extensions. Create and update go through the YAML template endpoints because the JSON-body update path is broken server-side. Idempotency compares script, `tagFields`, and `testCases` against the stored parser while ignoring whitespace and the auto-incremented version — a plain YAML diff reports a change on every run since the server reformats scripts on save. Clone and extension use the typed methods added in FalconPy 1.6.3, so both parser modules require it (enforced through the new parameterized check, without moving the global floor).

One gotcha worth flagging for reviewers: parser extensions only work against a CrowdStrike-managed OOTB parser, not a custom one, and the base ID has to be unversioned. The integration test discovers an OOTB parser at runtime to deal with that.

Tested with `ansible-test sanity` (clean) and a live end-to-end integration run covering the full create/read/update/clone/extension/delete lifecycle plus idempotency and check-mode.

Closes #705