### PR TITLE
Bump v4.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,41 @@ Ansible CrowdStrike Falcon Collection Release Notes
 
 .. contents:: Topics
 
+v4.13.0
+=======
+
+Release Summary
+---------------
+
+| Release Date: 2026-07-16
+| `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.13.0>`__
+
+Minor Changes
+-------------
+
+- Raised the enforced minimum FalconPy version from ``1.3.0`` to ``1.5.0`` across all modules, lookup plugins, and inventory plugins. Documentation now reflects a minimum of Python ``3.8`` and FalconPy ``1.5.0``.
+- Version comparisons now use numeric tuple comparison instead of string comparison, fixing incorrect results for multi-digit versions (e.g. ``1.10.0``).
+- ngsiem_data_connection - new module to create, update, delete, and pause/resume NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+- ngsiem_data_connection_info - new module to get information about NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+- ngsiem_data_connector_info - new module to get information about available NG-SIEM data connectors (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+- ngsiem_parser - new module to create, update, clone, and delete NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
+- ngsiem_parser_info - new module to get information about NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
+
+Bugfixes
+--------
+
+- correlation_rule module - Use the ``rule_id`` field instead of ``id`` when updating, publishing, and deleting rules so operations on rules with multiple versions no longer fail with a "rule not found" error (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).
+- correlation_rule_info module - Use the ``rule_id`` field when looking up latest rule versions so ``include_latest_version`` works for rules with multiple versions (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).
+
+New Modules
+-----------
+
+- crowdstrike.falcon.ngsiem_data_connection - Manage NG\-SIEM data connections
+- crowdstrike.falcon.ngsiem_data_connection_info - Get information about NG\-SIEM data connections
+- crowdstrike.falcon.ngsiem_data_connector_info - Get information about available NG\-SIEM data connectors
+- crowdstrike.falcon.ngsiem_parser - Manage NG\-SIEM parsers
+- crowdstrike.falcon.ngsiem_parser_info - Get information about NG\-SIEM parsers
+
 v4.12.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -636,6 +636,59 @@ releases:
         name: correlation_rule_info
         namespace: ''
     release_date: '2026-05-17'
+  4.13.0:
+    changes:
+      bugfixes:
+        - correlation_rule module - Use the ``rule_id`` field instead of ``id`` when
+          updating, publishing, and deleting rules so operations on rules with multiple
+          versions no longer fail with a "rule not found" error (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).
+        - correlation_rule_info module - Use the ``rule_id`` field when looking up
+          latest rule versions so ``include_latest_version`` works for rules with
+          multiple versions (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).
+      minor_changes:
+        - Raised the enforced minimum FalconPy version from ``1.3.0`` to ``1.5.0``
+          across all modules, lookup plugins, and inventory plugins. Documentation
+          now reflects a minimum of Python ``3.8`` and FalconPy ``1.5.0``.
+        - Version comparisons now use numeric tuple comparison instead of string comparison,
+          fixing incorrect results for multi-digit versions (e.g. ``1.10.0``).
+        - ngsiem_data_connection - new module to create, update, delete, and pause/resume
+          NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+        - ngsiem_data_connection_info - new module to get information about NG-SIEM
+          data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+        - ngsiem_data_connector_info - new module to get information about available
+          NG-SIEM data connectors (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
+        - ngsiem_parser - new module to create, update, clone, and delete NG-SIEM
+          parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
+        - ngsiem_parser_info - new module to get information about NG-SIEM parsers
+          (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
+      release_summary: '| Release Date: 2026-07-16
+
+        | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.13.0>`__
+
+        '
+    fragments:
+      - 4.13.0.yaml
+      - 701-fix-correlation-rule-id-field.yml
+      - 704-add-ngsiem-data-connection-modules.yml
+      - 705-add-ngsiem-parser-modules.yml
+      - 705-bump-falconpy-minimum.yml
+    modules:
+      - description: Manage NG\-SIEM data connections
+        name: ngsiem_data_connection
+        namespace: ''
+      - description: Get information about NG\-SIEM data connections
+        name: ngsiem_data_connection_info
+        namespace: ''
+      - description: Get information about available NG\-SIEM data connectors
+        name: ngsiem_data_connector_info
+        namespace: ''
+      - description: Manage NG\-SIEM parsers
+        name: ngsiem_parser
+        namespace: ''
+      - description: Get information about NG\-SIEM parsers
+        name: ngsiem_parser_info
+        namespace: ''
+    release_date: '2026-07-16'
   4.2.0:
     changes:
       minor_changes:

--- a/changelogs/fragments/4.13.0.yaml
+++ b/changelogs/fragments/4.13.0.yaml
@@ -1,0 +1,3 @@
+release_summary: |
+  | Release Date: 2026-07-16
+  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.13.0>`__

--- a/changelogs/fragments/4.13.0.yaml
+++ b/changelogs/fragments/4.13.0.yaml
@@ -1,3 +1,0 @@
-release_summary: |
-  | Release Date: 2026-07-16
-  | `Release Notes: <https://github.com/CrowdStrike/ansible_collection_falcon/releases/tag/4.13.0>`__

--- a/changelogs/fragments/701-fix-correlation-rule-id-field.yml
+++ b/changelogs/fragments/701-fix-correlation-rule-id-field.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - correlation_rule module - Use the ``rule_id`` field instead of ``id`` when updating, publishing, and deleting rules so operations on rules with multiple versions no longer fail with a "rule not found" error (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).
-  - correlation_rule_info module - Use the ``rule_id`` field when looking up latest rule versions so ``include_latest_version`` works for rules with multiple versions (https://github.com/CrowdStrike/ansible_collection_falcon/issues/701).

--- a/changelogs/fragments/704-add-ngsiem-data-connection-modules.yml
+++ b/changelogs/fragments/704-add-ngsiem-data-connection-modules.yml
@@ -1,5 +1,0 @@
----
-minor_changes:
-  - ngsiem_data_connection - new module to create, update, delete, and pause/resume NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
-  - ngsiem_data_connection_info - new module to get information about NG-SIEM data connections (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)
-  - ngsiem_data_connector_info - new module to get information about available NG-SIEM data connectors (https://github.com/CrowdStrike/ansible_collection_falcon/issues/704)

--- a/changelogs/fragments/705-add-ngsiem-parser-modules.yml
+++ b/changelogs/fragments/705-add-ngsiem-parser-modules.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - ngsiem_parser - new module to create, update, clone, and delete NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)
-  - ngsiem_parser_info - new module to get information about NG-SIEM parsers (https://github.com/CrowdStrike/ansible_collection_falcon/issues/705)

--- a/changelogs/fragments/705-bump-falconpy-minimum.yml
+++ b/changelogs/fragments/705-bump-falconpy-minimum.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - Raised the enforced minimum FalconPy version from ``1.3.0`` to ``1.5.0`` across all modules, lookup plugins, and inventory plugins. Documentation now reflects a minimum of Python ``3.8`` and FalconPy ``1.5.0``.
-  - Version comparisons now use numeric tuple comparison instead of string comparison, fixing incorrect results for multi-digit versions (e.g. ``1.10.0``).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: crowdstrike
 name: falcon
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 4.12.0
+version: 4.13.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Bumps the collection from 4.12.0 to 4.13.0. This minor release pulls in the NG-SIEM data connection and parser modules, raises the minimum FalconPy version to 1.5.0, and fixes the correlation_rule rule_id lookup.

Minor changes
- New `ngsiem_data_connection`, `ngsiem_data_connection_info`, and `ngsiem_data_connector_info` modules
- New `ngsiem_parser` and `ngsiem_parser_info` modules
- Raised minimum FalconPy version from 1.3.0 to 1.5.0
- Version comparisons now use numeric tuple comparison

Bugfixes
- `correlation_rule` and `correlation_rule_info` now use the `rule_id` field so operations on rules with multiple versions work correctly